### PR TITLE
Support for `usePagination` prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Support for `usePagination` prop.
+
+### Changed
+- Rename enum values for `showPaginationDots`.
 
 ## [0.1.0] - 2019-09-10
 ### Added

--- a/react/components/Slider.tsx
+++ b/react/components/Slider.tsx
@@ -14,7 +14,7 @@ interface Props {
   label?: string
   showNavigationArrows: 'mobileOnly' | 'desktopOnly' | 'always' | 'never'
   infinite: boolean
-  showPaginationDots: 'always' | 'never' | 'desktopOnly' | 'mobileOnly'
+  showPaginationDots: 'mobileOnly' | 'desktopOnly' | 'always' | 'never'
   slideTransition?: {
     /** Transition speed in ms */
     speed: number

--- a/react/components/Slider.tsx
+++ b/react/components/Slider.tsx
@@ -14,7 +14,7 @@ interface Props {
   label?: string
   showNavigationArrows: 'mobileOnly' | 'desktopOnly' | 'always' | 'never'
   infinite: boolean
-  showPaginationDots: 'visible' | 'hidden' | 'desktopOnly' | 'mobileOnly'
+  showPaginationDots: 'always' | 'never' | 'desktopOnly' | 'mobileOnly'
   slideTransition?: {
     /** Transition speed in ms */
     speed: number
@@ -28,7 +28,7 @@ interface Props {
     stopOnHover?: boolean
   }
   navigationStep: number | 'page'
-  usePaginationOnDrag: boolean
+  usePagination: boolean
   itemsPerPage: {
     desktop: number
     tablet: number
@@ -43,6 +43,7 @@ const Slider: FC<Props> = ({
   showPaginationDots,
   infinite,
   navigationStep,
+  usePagination = true,
   slideTransition = {
     speed: 400,
     delay: 0,
@@ -69,27 +70,28 @@ const Slider: FC<Props> = ({
     (showNavigationArrows === 'desktopOnly' && !isMobile)
   )
   const shouldShowPaginationDots = !!(
-    showPaginationDots === 'visible' ||
+    showPaginationDots === 'always' ||
     (showPaginationDots === 'mobileOnly' && isMobile) ||
     (showPaginationDots === 'desktopOnly' && !isMobile)
   )
   const resolvedNavigationStep =
     navigationStep === 'page' ? sliderState.slidesPerPage : navigationStep
 
-  useScreenResize(containerRef, itemsPerPage)
+  useScreenResize(containerRef, infinite, itemsPerPage)
 
   return (
     <section
       aria-roledescription="carousel"
       aria-label={label}
-      className={`w-100 flex items-center relative overflow-hidden ${sliderCSS.container ||
-        ''}`}
+      className={`w-100 flex items-center relative ${
+        usePagination ? 'overflow-hidden' : 'overflow-x-scroll'
+      } ${sliderCSS.container || ''}`}
       ref={containerRef}
     >
       <SliderTrack slideTransition={slideTransition}>
         <SlideList totalItems={totalItems}>{children}</SlideList>
       </SliderTrack>
-      {shouldShowArrows && (
+      {shouldShowArrows && usePagination && (
         <Fragment>
           <Arrow
             orientation="left"
@@ -107,7 +109,7 @@ const Slider: FC<Props> = ({
           />
         </Fragment>
       )}
-      {shouldShowPaginationDots && (
+      {shouldShowPaginationDots && usePagination && (
         <PaginationDots
           navigationStep={resolvedNavigationStep}
           totalItems={totalItems}

--- a/react/components/Slider.tsx
+++ b/react/components/Slider.tsx
@@ -39,8 +39,8 @@ interface Props {
 const Slider: FC<Props> = ({
   label = 'slider',
   children,
-  showNavigationArrows,
-  showPaginationDots,
+  showNavigationArrows = 'always',
+  showPaginationDots = 'always',
   infinite,
   navigationStep,
   usePagination = true,

--- a/react/hooks/useScreenResize.ts
+++ b/react/hooks/useScreenResize.ts
@@ -4,6 +4,7 @@ import { useSliderDispatch } from '../components/SliderContext'
 
 export const useScreenResize = (
   containerRef: RefObject<HTMLDivElement>,
+  infinite: boolean,
   itemsPerPage: {
     desktop: number
     tablet: number
@@ -41,7 +42,7 @@ export const useScreenResize = (
       }
     }
     const onResize = (value?: UIEvent): void => {
-      setNewState(!value)
+      setNewState(!value || infinite)
     }
     setNewState(false)
 


### PR DESCRIPTION
#### What is the purpose of this pull request?

This adds the expected functionality toggled by the `usePagination` prop.
If set to `true`, the Slider behaves normally, using pagination to navigate. If this is set to `false`, the Slider does not render `Arrows` nor `PaginationDots` components and uses `overflow-x: scroll` to enable a `fluid` sliding effect using just the browser's scrolling.

#### What problem is this solving?

That prop was already in the API but did nothing.

#### How should this be manually tested?

https://sliderwithnopagination--storecomponents.myvtex.com/about-us

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
