### PR TITLE
Update logic used to generate each individual slide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- How the `SliderTrack` component creates each individual slide.
+
+### Added
+- Suppor for the use of `blocks` that render a list of components that should be individual slides.
 
 ## [0.4.1] - 2019-09-20
 ### Fixed

--- a/react/components/Slide.tsx
+++ b/react/components/Slide.tsx
@@ -1,0 +1,48 @@
+import React, { FC, useRef, useLayoutEffect } from 'react'
+
+import { useSliderState } from './SliderContext'
+import sliderCSS from './slider.css'
+
+interface Props {
+  node: ChildNode
+  index: number
+}
+
+const Slide: FC<Props> = ({ node, index }) => {
+  const {
+    slideWidth,
+    slidesPerPage,
+    currentSlide,
+    totalItems,
+  } = useSliderState()
+
+  const slideRef = useRef<HTMLDivElement>(null)
+
+  useLayoutEffect(() => {
+    if (slideRef.current) {
+      slideRef.current.appendChild(node)
+    }
+  }, [node])
+
+  const isSlideVisibile = (index: number): boolean => {
+    return index >= currentSlide && index < currentSlide + slidesPerPage
+  }
+
+  return (
+    <div
+      ref={slideRef}
+      key={index}
+      className={`flex relative ${sliderCSS.sliderItem || ''}`}
+      data-index={index}
+      style={{
+        width: `${slideWidth}px`,
+      }}
+      aria-hidden={isSlideVisibile(index) ? 'false' : 'true'}
+      role="group"
+      aria-roledescription="slide"
+      aria-label={`${index + 1} of ${totalItems}`}
+    />
+  )
+}
+
+export default Slide


### PR DESCRIPTION
#### What does this PR do? \*

Changes the way the `SliderTrack` component handles its received children and how it renders them into individual slides. It used to just loop over the `children` received as props to the component, now it creates individual slides based on the `childNodes` actually rendered.
Now `slider-layout` can support the use of `blocks` that render a list of other `blocks` (such as the upcoming `<ImageList />` component).

#### How to test it? \*

https://sliderchildren--storecomponents.myvtex.com/about-us

Each of the two first slides is an image rendered by a single `image-list` block.

#### Describe alternatives you've considered if any. \*

Another way to enable this would be to implement support for that kind of `block` on `render-runtime`.