### PR TITLE
Update CSS handles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- CSS handles.
+- `children` rendered on a slide has `w-100` token.
 
 ## [0.3.0] - 2019-09-17
 ### Added

--- a/react/components/Slider.tsx
+++ b/react/components/Slider.tsx
@@ -48,7 +48,7 @@ const Slider: FC = ({ children }) => {
       style={{ WebkitOverflowScrolling: !usePagination ? 'touch' : undefined }}
       className={`w-100 flex items-center relative ${
         usePagination ? 'overflow-hidden' : 'overflow-x-scroll'
-      } ${sliderCSS.container || ''}`}
+      } ${sliderCSS.layoutContainer}`}
       ref={containerRef}
     >
       <SliderTrack>{children}</SliderTrack>

--- a/react/components/SliderTrack.tsx
+++ b/react/components/SliderTrack.tsx
@@ -24,7 +24,7 @@ const SliderTrack: FC = ({ children }) => {
 
   return (
     <div
-      className={`${sliderCSS.slider || ''} flex relative pa0 ma0`}
+      className={`${sliderCSS.sliderTrack} flex relative pa0 ma0`}
       style={{
         transition: isOnTouchMove
           ? undefined
@@ -38,7 +38,7 @@ const SliderTrack: FC = ({ children }) => {
       {React.Children.toArray(children).map((child, index) => (
         <div
           key={index}
-          className={`flex relative ${sliderCSS.sliderItem || ''}`}
+          className={`flex relative ${sliderCSS.slide}`}
           data-index={index}
           style={{
             width: `${slideWidth}px`,
@@ -52,7 +52,7 @@ const SliderTrack: FC = ({ children }) => {
           aria-roledescription="slide"
           aria-label={`${index + 1} of ${totalItems}`}
         >
-          {child}
+          <div className="w-100">{child}</div>
         </div>
       ))}
     </div>

--- a/react/components/slider.css
+++ b/react/components/slider.css
@@ -1,10 +1,10 @@
-.container {
+.layoutContainer {
 }
 .sliderContainer {
 }
-.slider {
+.sliderTrack {
 }
-.sliderItem {
+.slide {
 }
 .leftArrow {
 }

--- a/react/typings/css.d.ts
+++ b/react/typings/css.d.ts
@@ -4,10 +4,10 @@ declare module '*.css' {
 }
 
 interface CSSHandles {
-  container: string
+  layoutContainer: string
   sliderContainer: string
-  slider: string
-  sliderItem: string
+  sliderTrack: string
+  slide: string
   leftArrow: string
   rightArrow: string
   dotsContainer: string


### PR DESCRIPTION
#### What does this PR do? \*

Update the naming used on CSS handles.
Make `children` being rendered on each slide occupy `width: 100%` available to them, this prevents overflow and also guarantees that elements smaller then `sliderWidth` will not be rendered with whitespace around them. 

#### How to test it? \*

https://sliderchildren--storecomponents.myvtex.com/about-us

This page has 3 `slider-layout` blocks, each one with different types of children.
