### PR TITLE
Prevent slides from rendering before slideWidth is calculated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Prevent slides from rendering before `slideWidth` is calculated.
 
 ## [0.4.0] - 2019-09-17
 ### Added

--- a/react/components/Slider.tsx
+++ b/react/components/Slider.tsx
@@ -17,14 +17,12 @@ const Slider: FC = ({ children }) => {
     showPaginationDots,
     usePagination,
     label,
-    slideWidth,
   } = useSliderState()
   const containerRef = useRef<HTMLDivElement>(null)
   const controls = `${label
     .toLowerCase()
     .trim()
     .replace(/ /g, '-')}-items`
-  const isSliderReady = slideWidth > 0
 
   useScreenResize(containerRef, device)
   const { onTouchEnd, onTouchStart, onTouchMove } = useTouchHandlers()
@@ -53,19 +51,15 @@ const Slider: FC = ({ children }) => {
       } ${sliderCSS.layoutContainer}`}
       ref={containerRef}
     >
-      {isSliderReady && (
+      <SliderTrack>{children}</SliderTrack>
+      {shouldShowArrows && usePagination && (
         <Fragment>
-          <SliderTrack>{children}</SliderTrack>
-          {shouldShowArrows && usePagination && (
-            <Fragment>
-              <Arrow orientation="left" controls={controls} />
-              <Arrow orientation="right" controls={controls} />
-            </Fragment>
-          )}
-          {shouldShowPaginationDots && usePagination && (
-            <PaginationDots controls={controls} />
-          )}
+          <Arrow orientation="left" controls={controls} />
+          <Arrow orientation="right" controls={controls} />
         </Fragment>
+      )}
+      {shouldShowPaginationDots && usePagination && (
+        <PaginationDots controls={controls} />
       )}
     </section>
   )

--- a/react/components/Slider.tsx
+++ b/react/components/Slider.tsx
@@ -17,12 +17,14 @@ const Slider: FC = ({ children }) => {
     showPaginationDots,
     usePagination,
     label,
+    slideWidth,
   } = useSliderState()
   const containerRef = useRef<HTMLDivElement>(null)
   const controls = `${label
     .toLowerCase()
     .trim()
     .replace(/ /g, '-')}-items`
+  const isSliderReady = slideWidth > 0
 
   useScreenResize(containerRef, device)
   const { onTouchEnd, onTouchStart, onTouchMove } = useTouchHandlers()
@@ -51,15 +53,19 @@ const Slider: FC = ({ children }) => {
       } ${sliderCSS.layoutContainer}`}
       ref={containerRef}
     >
-      <SliderTrack>{children}</SliderTrack>
-      {shouldShowArrows && usePagination && (
+      {isSliderReady && (
         <Fragment>
-          <Arrow orientation="left" controls={controls} />
-          <Arrow orientation="right" controls={controls} />
+          <SliderTrack>{children}</SliderTrack>
+          {shouldShowArrows && usePagination && (
+            <Fragment>
+              <Arrow orientation="left" controls={controls} />
+              <Arrow orientation="right" controls={controls} />
+            </Fragment>
+          )}
+          {shouldShowPaginationDots && usePagination && (
+            <PaginationDots controls={controls} />
+          )}
         </Fragment>
-      )}
-      {shouldShowPaginationDots && usePagination && (
-        <PaginationDots controls={controls} />
       )}
     </section>
   )

--- a/react/components/SliderTrack.tsx
+++ b/react/components/SliderTrack.tsx
@@ -1,5 +1,5 @@
 import React, { FC, Fragment } from 'react'
-import { useSSR } from 'vtex.render-runtime/core/main'
+import { useSSR } from 'vtex.render-runtime'
 
 import { useSliderState } from './SliderContext'
 import sliderCSS from './slider.css'

--- a/react/components/SliderTrack.tsx
+++ b/react/components/SliderTrack.tsx
@@ -1,4 +1,5 @@
-import React, { FC } from 'react'
+import React, { FC, Fragment } from 'react'
+import { useSSR } from 'vtex.render-runtime/core/main'
 
 import { useSliderState } from './SliderContext'
 import sliderCSS from './slider.css'
@@ -13,6 +14,9 @@ const SliderTrack: FC = ({ children }) => {
     isOnTouchMove,
     slideTransition: { speed, timing, delay },
   } = useSliderState()
+  const isSSR = useSSR()
+
+  const childrenArray = React.Children.toArray(children)
 
   const isSlideVisibile = (
     index: number,
@@ -20,6 +24,35 @@ const SliderTrack: FC = ({ children }) => {
     slidesToShow: number
   ): boolean => {
     return index >= currentSlide && index < currentSlide + slidesToShow
+  }
+
+  if (isSSR) {
+    const slideWidthPercentage = 100 / slidesPerPage
+
+    return (
+      <Fragment>
+        {childrenArray.slice(0, slidesPerPage).map((child, index) => (
+          <div
+            key={index}
+            className={`flex relative ${sliderCSS.slide}`}
+            data-index={index}
+            style={{
+              width: `${slideWidthPercentage}%`,
+            }}
+            aria-hidden={
+              isSlideVisibile(index, currentSlide, slidesPerPage)
+                ? 'false'
+                : 'true'
+            }
+            role="group"
+            aria-roledescription="slide"
+            aria-label={`${index + 1} of ${totalItems}`}
+          >
+            <div className="w-100">{child}</div>
+          </div>
+        ))}
+      </Fragment>
+    )
   }
 
   return (
@@ -35,7 +68,7 @@ const SliderTrack: FC = ({ children }) => {
       aria-atomic="false"
       aria-live="polite"
     >
-      {React.Children.toArray(children).map((child, index) => (
+      {childrenArray.map((child, index) => (
         <div
           key={index}
           className={`flex relative ${sliderCSS.slide}`}

--- a/react/typings/vtex.render-runtime.d.ts
+++ b/react/typings/vtex.render-runtime.d.ts
@@ -1,0 +1,82 @@
+/* eslint @typescript-eslint/no-explicit-any: 0 */
+/* Typings for `render-runtime` */
+declare module 'vtex.render-runtime' {
+  import { Component, ReactElement } from 'react'
+
+  export interface RenderContextProps {
+    runtime: {
+      account: string
+    }
+  }
+
+  export interface InjectedRuntime {
+    runtime: RenderRuntime
+  }
+
+  interface Pages {
+    [name: string]: Page
+  }
+
+  interface Route {
+    domain: string
+    blockId: string
+    canonicalPath?: string
+    id: string
+    params: Record<string, string>
+    path: string
+    title?: string
+  }
+
+  interface Culture {
+    availableLocales: string[]
+    locale: string
+    language: string
+    country: string
+    currency: string
+  }
+
+  export interface RenderRuntime {
+    account: string
+    accountId: string
+    appsEtag: string
+    workspace: string
+    disableSSR: boolean
+    hints: {
+      desktop: boolean
+      mobile: boolean
+      phone: boolean
+      tablet: boolean
+    }
+    page: string
+    route: Route
+    version: string
+    culture: Culture
+    pages: Pages
+    preview: boolean
+    production: boolean
+    publicEndpoint: string
+    renderMajor: number
+    query?: Record<string, string>
+    start: boolean
+    runtimeMeta: {
+      version: string
+      config?: any
+    }
+    settings: {
+      [app: string]: any
+    }
+    segmentToken: string
+    rootPath?: string
+    workspaceCookie: string
+    hasNewExtensions: boolean
+  }
+
+  export const Link: any
+  export const NoSSR: any
+  export const RenderContextConsumer: ReactElement
+  export const canUseDOM: boolean
+  export const withRuntimeContext: any
+  export const Helmet: any
+  export const useSSR: () => boolean
+  export const useRuntime: () => RenderRuntime
+}


### PR DESCRIPTION
#### What does this PR do? \*

Fixes a bug where the slides would be rendered into the page before their width was calculated, which resulted in a strange layout shift.

#### How to test it? \*

This workspace has the `slider-layout` linked to it and also a `vtex.shelf` using the new `Slider` component at:

https://sliderlayout--storecomponents.myvtex.com
https://sliderlayout--storecomponents.myvtex.com/about-us
