### PR TITLE
Use contexts from `vtex.list-context`

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -10,11 +10,13 @@
   },
   "dependencies": {
     "vtex.device-detector": "0.x",
-    "vtex.store-icons": "0.x"
+    "vtex.store-icons": "0.x",
+    "vtex.list-context": "0.x"
   },
   "builders": {
     "react": "3.x",
     "store": "0.x",
+    "messages": "1.x",
     "docs": "0.x"
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"

--- a/react/SliderLayout.tsx
+++ b/react/SliderLayout.tsx
@@ -1,5 +1,9 @@
 import React from 'react'
 import { defineMessages } from 'react-intl'
+import {
+  useProductSummaryListState,
+  useImageListState,
+} from 'vtex.list-context'
 
 import Slider from './components/Slider'
 import { SliderContextProvider } from './components/SliderContext'
@@ -15,7 +19,11 @@ const SliderLayout: StorefrontFunctionComponent<
   children,
   ...contextProps
 }) => {
-  const totalSlides = totalItems || React.Children.count(children)
+  const productList = useProductSummaryListState() || []
+  const imageList = useImageListState() || []
+  const totalSlides =
+    totalItems ||
+    React.Children.count(children) + productList.length + imageList.length
 
   return (
     <SliderContextProvider totalItems={totalSlides} {...contextProps}>
@@ -62,24 +70,24 @@ SliderLayout.schema = {
   properties: {
     infinite: {
       default: true,
-      title: messages.sliderInfinite,
+      title: messages.sliderInfinite.id,
       type: 'boolean',
     },
     showNavigationArrows: {
       default: 'always',
       enum: ['mobileOnly', 'desktopOnly', 'always', 'never'],
-      title: messages.sliderShowNavigation,
+      title: messages.sliderShowNavigation.id,
       type: 'string',
     },
     showPaginationDots: {
       default: 'always',
       enum: ['mobileOnly', 'desktopOnly', 'always', 'never'],
-      title: messages.sliderShowPaginationDots,
+      title: messages.sliderShowPaginationDots.id,
       type: 'string',
     },
     usePagination: {
       default: true,
-      title: messages.sliderUsePagination,
+      title: messages.sliderUsePagination.id,
       type: 'boolean',
     },
   },

--- a/react/SliderLayout.tsx
+++ b/react/SliderLayout.tsx
@@ -1,9 +1,6 @@
 import React from 'react'
 import { defineMessages } from 'react-intl'
-import {
-  useProductSummaryListState,
-  useImageListState,
-} from 'vtex.list-context'
+import { useListContext } from 'vtex.list-context'
 
 import Slider from './components/Slider'
 import { SliderContextProvider } from './components/SliderContext'
@@ -19,11 +16,8 @@ const SliderLayout: StorefrontFunctionComponent<
   children,
   ...contextProps
 }) => {
-  const productList = useProductSummaryListState() || []
-  const imageList = useImageListState() || []
-  const totalSlides =
-    totalItems ||
-    React.Children.count(children) + productList.length + imageList.length
+  const { list } = useListContext() || []
+  const totalSlides = totalItems || React.Children.count(children) + list.length
 
   return (
     <SliderContextProvider totalItems={totalSlides} {...contextProps}>

--- a/react/components/SliderContext.tsx
+++ b/react/components/SliderContext.tsx
@@ -149,7 +149,7 @@ function useSliderState() {
   const context = useContext(SliderStateContext)
   if (context === undefined) {
     throw new Error(
-      'useAppVersionState must be used within a SliderContextProvider'
+      'useSliderState must be used within a SliderContextProvider'
     )
   }
   return context
@@ -160,7 +160,7 @@ function useSliderDispatch() {
 
   if (context === undefined) {
     throw new Error(
-      'useAppVersionDispatch must be used within a SliderContextProvider'
+      'useSliderDispatch must be used within a SliderContextProvider'
     )
   }
   return context

--- a/react/components/SliderTrack.tsx
+++ b/react/components/SliderTrack.tsx
@@ -21,6 +21,7 @@ const SliderTrack: FC<{ totalItems: number }> = ({ children, totalItems }) => {
   const productList = useProductSummaryListState() || []
   const imageList = useImageListState() || []
 
+  // TO-DO: Enable the user to control WHERE items from lists should be inserted
   const childrenArray = React.Children.toArray(children)
     .concat(productList)
     .concat(imageList)

--- a/react/components/SliderTrack.tsx
+++ b/react/components/SliderTrack.tsx
@@ -1,9 +1,6 @@
 import React, { FC, Fragment } from 'react'
 import { useSSR } from 'vtex.render-runtime'
-import {
-  useProductSummaryListState,
-  useImageListState,
-} from 'vtex.list-context'
+import { useListContext } from 'vtex.list-context'
 
 import { useSliderState } from './SliderContext'
 import sliderCSS from './slider.css'
@@ -18,13 +15,10 @@ const SliderTrack: FC<{ totalItems: number }> = ({ children, totalItems }) => {
     slideTransition: { speed, timing, delay },
   } = useSliderState()
   const isSSR = useSSR()
-  const productList = useProductSummaryListState() || []
-  const imageList = useImageListState() || []
+  const { list } = useListContext()
 
   // TO-DO: Enable the user to control WHERE items from lists should be inserted
-  const childrenArray = React.Children.toArray(children)
-    .concat(productList)
-    .concat(imageList)
+  const childrenArray = React.Children.toArray(children).concat(list)
 
   const isSlideVisibile = (
     index: number,

--- a/react/components/SliderTrack.tsx
+++ b/react/components/SliderTrack.tsx
@@ -1,5 +1,9 @@
 import React, { FC, Fragment } from 'react'
 import { useSSR } from 'vtex.render-runtime'
+import {
+  useProductSummaryListState,
+  useImageListState,
+} from 'vtex.list-context'
 
 import { useSliderState } from './SliderContext'
 import sliderCSS from './slider.css'
@@ -14,8 +18,12 @@ const SliderTrack: FC<{ totalItems: number }> = ({ children, totalItems }) => {
     slideTransition: { speed, timing, delay },
   } = useSliderState()
   const isSSR = useSSR()
+  const productList = useProductSummaryListState() || []
+  const imageList = useImageListState() || []
 
   const childrenArray = React.Children.toArray(children)
+    .concat(productList)
+    .concat(imageList)
 
   const isSlideVisibile = (
     index: number,

--- a/react/components/SliderTrack.tsx
+++ b/react/components/SliderTrack.tsx
@@ -17,7 +17,6 @@ const SliderTrack: FC<{ totalItems: number }> = ({ children, totalItems }) => {
   const isSSR = useSSR()
   const { list } = useListContext()
 
-  // TO-DO: Enable the user to control WHERE items from lists should be inserted
   const childrenArray = React.Children.toArray(children).concat(list)
 
   const isSlideVisibile = (

--- a/react/typings/vtex.list-context.d.ts
+++ b/react/typings/vtex.list-context.d.ts
@@ -1,0 +1,1 @@
+declare module 'vtex.list-context'


### PR DESCRIPTION
#### What does this PR do? 

Enables `slider-layout` to consume content from the contexts exported by `vtex.list-context`.
In this PR, `slider-layout` can consume a list of images from `list-context.image-list` and a list of products from `list-context.product-list`. The content consumed by it is used to populate new slides.

#### How to test it? \*

In this page there are 3 `slider-layout`s being used:
- A `list-context.product-list` with a `slider-layout` inside of it.
- A `list-context.image-list` with a `slider-layout` inside of it.
- A `list-context.product-list` with a `list-context.image-list` inside of it, which has a `slider-layout` that contains two `flex-layout`s.

https://lists--storecomponents.myvtex.com/admin/cms/site-editor/about-us

#### Related to / Depends on \*

Initial release of `vtex.list-context`
