### PR TITLE
added carousel recipe to docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Recipe about how to use slider-layout as carousel
+
 ## [0.7.2] - 2019-12-05
 
 ## [0.7.1] - 2019-11-25

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,9 @@ Slider-Layout is a flexible solution for building `sliders` of `blocks` within V
 
 ![](https://user-images.githubusercontent.com/27777263/70230361-e839db00-1736-11ea-9f29-7c945c10a5f7.png)
 
+:warning: In order to use the `slider-layout` as a substitute to the `carousel` component, check this [recipe](https://vtex.io/docs/recipes/layout/building-a-carousel-through-lists-and-slider-layout) out.
+
+
 ## Configuration
 
 1. Add the slider-layout app to your theme's dependencies in the `manifest.json`, for example:
@@ -48,6 +51,7 @@ Slider-Layout is a flexible solution for building `sliders` of `blocks` within V
  }
 
 ```
+
 
 | Prop name              | Type                                                       | Description                                                                                                                                                                  | Default value                          |
 | ---------------------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------- |


### PR DESCRIPTION
#### What does this PR do? \*
Add carousel recipe to slider layout

This is important in order to ensure a carousel's flawless deprecation. 

RIP `vtex.carousel`

#### How to test it? \*

#### Describe alternatives you've considered, if any. \*

<!--- Optional -->

#### Related to / Depends on \*

<!--- Optional -->
