### PR TITLE
Prevent slider from "flashing" when transitioning from SSR to CSR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Slider would "flash" when transitioning from SSR to CSR.
 
 ## [0.8.0] - 2020-01-13
 ### Added

--- a/react/components/Slider.tsx
+++ b/react/components/Slider.tsx
@@ -22,7 +22,7 @@ const Slider: FC<Props> = ({
   infinite,
   showNavigationArrows,
   showPaginationDots,
-  usePagination,
+  usePagination: shouldUsePagination,
   arrowSize,
   fullWidth,
 }) => {
@@ -55,21 +55,22 @@ const Slider: FC<Props> = ({
       !shouldBeStaticList
   )
 
+  const touchStartHandler = (e: React.TouchEvent) =>
+    shouldUsePagination && !shouldBeStaticList ? onTouchStart(e) : null
+  const touchEndHandler = (e: React.TouchEvent) =>
+    shouldUsePagination && !shouldBeStaticList ? onTouchEnd(e) : null
+  const touchMoveHandler = (e: React.TouchEvent) =>
+    shouldUsePagination && !shouldBeStaticList ? onTouchMove(e) : null
+
   return (
     <section
-      onTouchStart={e =>
-        usePagination && !shouldBeStaticList ? onTouchStart(e) : null
-      }
-      onTouchEnd={e =>
-        usePagination && !shouldBeStaticList ? onTouchEnd(e) : null
-      }
-      onTouchMove={e =>
-        usePagination && !shouldBeStaticList ? onTouchMove(e) : null
-      }
+      onTouchStart={touchStartHandler}
+      onTouchEnd={touchEndHandler}
+      onTouchMove={touchMoveHandler}
       aria-roledescription="carousel"
       aria-label={label}
       style={{
-        WebkitOverflowScrolling: !usePagination ? 'touch' : undefined,
+        WebkitOverflowScrolling: !shouldUsePagination ? 'touch' : undefined,
         paddingLeft: fullWidth ? undefined : arrowSize * 2,
         paddingRight: fullWidth ? undefined : arrowSize * 2,
       }}
@@ -77,13 +78,13 @@ const Slider: FC<Props> = ({
     >
       <div
         className={`w-100 ${handles.sliderTrackContainer} ${
-          usePagination ? 'overflow-hidden' : 'overflow-x-scroll'
+          shouldUsePagination ? 'overflow-hidden' : 'overflow-x-scroll'
         }`}
         ref={containerRef}
       >
         <SliderTrack totalItems={totalItems}>{children}</SliderTrack>
       </div>
-      {shouldShowArrows && usePagination && (
+      {shouldShowArrows && shouldUsePagination && (
         <Fragment>
           <Arrow
             totalItems={totalItems}
@@ -101,7 +102,7 @@ const Slider: FC<Props> = ({
           />
         </Fragment>
       )}
-      {shouldShowPaginationDots && usePagination && (
+      {shouldShowPaginationDots && shouldUsePagination && (
         <PaginationDots totalItems={totalItems} controls={controls} />
       )}
     </section>

--- a/react/components/Slider.tsx
+++ b/react/components/Slider.tsx
@@ -27,7 +27,7 @@ const Slider: FC<Props> = ({
   fullWidth,
 }) => {
   const handles = useCssHandles(CSS_HANDLES)
-  const { isMobile, device } = useDevice()
+  const { isMobile } = useDevice()
   const { label } = useSliderState()
   const containerRef = useRef<HTMLDivElement>(null)
   const controls = `${label
@@ -36,7 +36,7 @@ const Slider: FC<Props> = ({
     .replace(/ /g, '-')}-items`
 
   useAutoplay(infinite, containerRef)
-  useScreenResize(containerRef, device, infinite)
+  useScreenResize(infinite)
   const { onTouchEnd, onTouchStart, onTouchMove } = useTouchHandlers({
     totalItems,
     infinite,
@@ -68,7 +68,7 @@ const Slider: FC<Props> = ({
       className={`w-100 flex items-center relative ${handles.sliderLayoutContainer}`}
     >
       <div
-        className={`flex w-100 ${handles.sliderTrackContainer} ${
+        className={`w-100 ${handles.sliderTrackContainer} ${
           usePagination ? 'overflow-hidden' : 'overflow-x-scroll'
         }`}
         ref={containerRef}

--- a/react/components/Slider.tsx
+++ b/react/components/Slider.tsx
@@ -28,7 +28,7 @@ const Slider: FC<Props> = ({
 }) => {
   const handles = useCssHandles(CSS_HANDLES)
   const { isMobile } = useDevice()
-  const { label } = useSliderState()
+  const { label, slidesPerPage } = useSliderState()
   const containerRef = useRef<HTMLDivElement>(null)
   const controls = `${label
     .toLowerCase()
@@ -40,23 +40,32 @@ const Slider: FC<Props> = ({
   const { onTouchEnd, onTouchStart, onTouchMove } = useTouchHandlers({
     infinite,
   })
+  const shouldBeStaticList = slidesPerPage >= totalItems
 
-  const shouldShowArrows = !!(
-    showNavigationArrows === 'always' ||
-    (showNavigationArrows === 'mobileOnly' && isMobile) ||
-    (showNavigationArrows === 'desktopOnly' && !isMobile)
+  const shouldShowArrows = Boolean(
+    (showNavigationArrows === 'always' ||
+      (showNavigationArrows === 'mobileOnly' && isMobile) ||
+      (showNavigationArrows === 'desktopOnly' && !isMobile)) &&
+      !shouldBeStaticList
   )
-  const shouldShowPaginationDots = !!(
-    showPaginationDots === 'always' ||
-    (showPaginationDots === 'mobileOnly' && isMobile) ||
-    (showPaginationDots === 'desktopOnly' && !isMobile)
+  const shouldShowPaginationDots = Boolean(
+    (showPaginationDots === 'always' ||
+      (showPaginationDots === 'mobileOnly' && isMobile) ||
+      (showPaginationDots === 'desktopOnly' && !isMobile)) &&
+      !shouldBeStaticList
   )
 
   return (
     <section
-      onTouchStart={e => (usePagination ? onTouchStart(e) : null)}
-      onTouchEnd={e => (usePagination ? onTouchEnd(e) : null)}
-      onTouchMove={e => (usePagination ? onTouchMove(e) : null)}
+      onTouchStart={e =>
+        usePagination && !shouldBeStaticList ? onTouchStart(e) : null
+      }
+      onTouchEnd={e =>
+        usePagination && !shouldBeStaticList ? onTouchEnd(e) : null
+      }
+      onTouchMove={e =>
+        usePagination && !shouldBeStaticList ? onTouchMove(e) : null
+      }
       aria-roledescription="carousel"
       aria-label={label}
       style={{

--- a/react/components/Slider.tsx
+++ b/react/components/Slider.tsx
@@ -38,7 +38,6 @@ const Slider: FC<Props> = ({
   useAutoplay(infinite, containerRef)
   useScreenResize(infinite)
   const { onTouchEnd, onTouchStart, onTouchMove } = useTouchHandlers({
-    totalItems,
     infinite,
   })
 

--- a/react/components/Slider.tsx
+++ b/react/components/Slider.tsx
@@ -37,36 +37,29 @@ const Slider: FC<Props> = ({
 
   useAutoplay(infinite, containerRef)
   useScreenResize(infinite)
+  const shouldBeStaticList = slidesPerPage >= totalItems
   const { onTouchEnd, onTouchStart, onTouchMove } = useTouchHandlers({
     infinite,
+    shouldUsePagination,
+    shouldBeStaticList,
   })
-  const shouldBeStaticList = slidesPerPage >= totalItems
 
   const shouldShowArrows = Boolean(
-    (showNavigationArrows === 'always' ||
+    showNavigationArrows === 'always' ||
       (showNavigationArrows === 'mobileOnly' && isMobile) ||
-      (showNavigationArrows === 'desktopOnly' && !isMobile)) &&
-      !shouldBeStaticList
+      (showNavigationArrows === 'desktopOnly' && !isMobile)
   )
   const shouldShowPaginationDots = Boolean(
-    (showPaginationDots === 'always' ||
+    showPaginationDots === 'always' ||
       (showPaginationDots === 'mobileOnly' && isMobile) ||
-      (showPaginationDots === 'desktopOnly' && !isMobile)) &&
-      !shouldBeStaticList
+      (showPaginationDots === 'desktopOnly' && !isMobile)
   )
-
-  const touchStartHandler = (e: React.TouchEvent) =>
-    shouldUsePagination && !shouldBeStaticList ? onTouchStart(e) : null
-  const touchEndHandler = (e: React.TouchEvent) =>
-    shouldUsePagination && !shouldBeStaticList ? onTouchEnd(e) : null
-  const touchMoveHandler = (e: React.TouchEvent) =>
-    shouldUsePagination && !shouldBeStaticList ? onTouchMove(e) : null
 
   return (
     <section
-      onTouchStart={touchStartHandler}
-      onTouchEnd={touchEndHandler}
-      onTouchMove={touchMoveHandler}
+      onTouchStart={onTouchEnd}
+      onTouchEnd={onTouchStart}
+      onTouchMove={onTouchMove}
       aria-roledescription="carousel"
       aria-label={label}
       style={{

--- a/react/components/SliderTrack.tsx
+++ b/react/components/SliderTrack.tsx
@@ -30,14 +30,17 @@ const SliderTrack: FC<{ totalItems: number }> = ({ children, totalItems }) => {
 
   return (
     <div
-      className={`${handles.sliderTrack} flex relative pa0 ma0`}
+      className={`${handles.sliderTrack} flex justify-around relative pa0 ma0`}
       style={{
         transition: isOnTouchMove
           ? undefined
           : `transform ${speed}ms ${timing}`,
         transitionDelay: `${delay}ms`,
         transform: `translate3d(${transform}%, 0, 0)`,
-        width: `${(totalItems * 100) / slidesPerPage}%`,
+        width:
+          slidesPerPage < totalItems
+            ? `${(totalItems * 100) / slidesPerPage}%`
+            : '100%',
       }}
       aria-atomic="false"
       aria-live="polite"

--- a/react/components/SliderTrack.tsx
+++ b/react/components/SliderTrack.tsx
@@ -1,5 +1,4 @@
-import React, { FC, Fragment } from 'react'
-import { useSSR } from 'vtex.render-runtime'
+import React, { FC } from 'react'
 import { useListContext } from 'vtex.list-context'
 import { useCssHandles } from 'vtex.css-handles'
 
@@ -16,47 +15,17 @@ const SliderTrack: FC<{ totalItems: number }> = ({ children, totalItems }) => {
     isOnTouchMove,
     slideTransition: { speed, timing, delay },
   } = useSliderState()
-  const isSSR = useSSR()
   const handles = useCssHandles(CSS_HANDLES)
   const { list } = useListContext()
 
   const childrenArray = React.Children.toArray(children).concat(list)
 
-  const isSlideVisibile = (
+  const isSlideVisible = (
     index: number,
     currentSlide: number,
     slidesToShow: number
   ): boolean => {
     return index >= currentSlide && index < currentSlide + slidesToShow
-  }
-
-  if (isSSR) {
-    const slideWidthPercentage = 100 / slidesPerPage
-
-    return (
-      <Fragment>
-        {childrenArray.slice(0, slidesPerPage).map((child, index) => (
-          <div
-            key={index}
-            className={`flex relative ${handles.slide}`}
-            data-index={index}
-            style={{
-              width: `${slideWidthPercentage}%`,
-            }}
-            aria-hidden={
-              isSlideVisibile(index, currentSlide, slidesPerPage)
-                ? 'false'
-                : 'true'
-            }
-            role="group"
-            aria-roledescription="slide"
-            aria-label={`${index + 1} of ${totalItems}`}
-          >
-            <div className="w-100">{child}</div>
-          </div>
-        ))}
-      </Fragment>
-    )
   }
 
   return (
@@ -67,7 +36,8 @@ const SliderTrack: FC<{ totalItems: number }> = ({ children, totalItems }) => {
           ? undefined
           : `transform ${speed}ms ${timing}`,
         transitionDelay: `${delay}ms`,
-        transform: `translate3d(${transform}px, 0, 0)`,
+        transform: `translate3d(${transform}%, 0, 0)`,
+        width: `${(totalItems * 100) / slidesPerPage}%`,
       }}
       aria-atomic="false"
       aria-live="polite"
@@ -78,10 +48,10 @@ const SliderTrack: FC<{ totalItems: number }> = ({ children, totalItems }) => {
           className={`flex relative ${handles.slide}`}
           data-index={index}
           style={{
-            width: `${slideWidth}px`,
+            width: `${slideWidth}%`,
           }}
           aria-hidden={
-            isSlideVisibile(index, currentSlide, slidesPerPage)
+            isSlideVisible(index, currentSlide, slidesPerPage)
               ? 'false'
               : 'true'
           }

--- a/react/hooks/useScreenResize.ts
+++ b/react/hooks/useScreenResize.ts
@@ -1,51 +1,29 @@
-import { useEffect, RefObject } from 'react'
+import { useEffect } from 'react'
+import { useDevice } from 'vtex.device-detector'
 
 import { useSliderDispatch, useSliderState } from '../components/SliderContext'
 
-export const useScreenResize = (
-  containerRef: RefObject<HTMLDivElement>,
-  device: 'desktop' | 'tablet' | 'phone',
-  infinite: boolean
-) => {
+export const useScreenResize = (infinite: boolean) => {
   const {
     navigationStep,
     isPageNavigationStep,
     itemsPerPage,
   } = useSliderState()
+  const { device } = useDevice()
   const dispatch = useSliderDispatch()
 
   useEffect(() => {
     const setNewState = (shouldCorrectItemPosition: boolean) => {
-      if (containerRef && containerRef.current) {
-        const containerWidth = containerRef.current.offsetWidth
-        const slideWidth: number = Math.round(
-          containerWidth / itemsPerPage[device]
-        )
-        dispatch({
-          type: 'LOAD_AND_CORRECT',
-          payload: {
-            slidesPerPage: itemsPerPage[device],
-            deviceType: device,
-            navigationStep: isPageNavigationStep
-              ? itemsPerPage[device]
-              : navigationStep,
-            containerWidth,
-            slideWidth,
-            shouldCorrectItemPosition,
-          },
-        })
-      } else {
-        dispatch({
-          type: 'LOAD',
-          payload: {
-            slidesToShow: itemsPerPage[device],
-            deviceType: device,
-            navigationStep: isPageNavigationStep
-              ? itemsPerPage[device]
-              : navigationStep,
-          },
-        })
-      }
+      dispatch({
+        type: 'ADJUST_ON_RESIZE',
+        payload: {
+          shouldCorrectItemPosition,
+          slidesPerPage: itemsPerPage[device],
+          navigationStep: isPageNavigationStep
+            ? itemsPerPage[device]
+            : navigationStep,
+        },
+      })
     }
     const onResize = (value?: UIEvent): void => {
       setNewState(!value || infinite)
@@ -55,11 +33,11 @@ export const useScreenResize = (
     window.addEventListener('resize', onResize)
     return () => window.removeEventListener('resize', onResize)
   }, [
-    device,
-    containerRef,
     infinite,
-    navigationStep,
-    isPageNavigationStep,
+    dispatch,
     itemsPerPage,
+    device,
+    isPageNavigationStep,
+    navigationStep,
   ])
 }

--- a/react/hooks/useTouchHandlers.ts
+++ b/react/hooks/useTouchHandlers.ts
@@ -5,19 +5,14 @@ import { useSliderDispatch, useSliderState } from '../components/SliderContext'
 
 const SWIPE_THRESHOLD = 75
 
-export const useTouchHandlers = ({
-  infinite,
-}: {
-  totalItems: number
-  infinite: boolean
-}) => {
+export const useTouchHandlers = ({ infinite }: { infinite: boolean }) => {
   const dispatch = useSliderDispatch()
   const { transform } = useSliderState()
   const { goForward, goBack } = useSliderControls(infinite)
 
   const [touchState, setTouchState] = useState({
     touchStartX: 0,
-    touchInitialTransform: 0,
+    touchInitialTransform: transform,
   })
 
   const onTouchStart = (e: React.TouchEvent) => {
@@ -29,7 +24,8 @@ export const useTouchHandlers = ({
     const currentX = e.touches[0].clientX
 
     const newTransform =
-      touchState.touchInitialTransform + (currentX - touchState.touchStartX)
+      touchState.touchInitialTransform +
+      (currentX - touchState.touchStartX) / 100
 
     dispatch({
       type: 'TOUCH',

--- a/react/hooks/useTouchHandlers.ts
+++ b/react/hooks/useTouchHandlers.ts
@@ -5,7 +5,17 @@ import { useSliderDispatch, useSliderState } from '../components/SliderContext'
 
 const SWIPE_THRESHOLD = 75
 
-export const useTouchHandlers = ({ infinite }: { infinite: boolean }) => {
+interface Args {
+  infinite: boolean
+  shouldBeStaticList: boolean
+  shouldUsePagination: boolean
+}
+
+export const useTouchHandlers = ({
+  infinite,
+  shouldBeStaticList,
+  shouldUsePagination,
+}: Args) => {
   const dispatch = useSliderDispatch()
   const { transform } = useSliderState()
   const { goForward, goBack } = useSliderControls(infinite)
@@ -14,6 +24,14 @@ export const useTouchHandlers = ({ infinite }: { infinite: boolean }) => {
     touchStartX: 0,
     touchInitialTransform: transform,
   })
+
+  if (shouldBeStaticList || !shouldUsePagination) {
+    return {
+      onTouchStart: undefined,
+      onTouchMove: undefined,
+      onTouchEnd: undefined,
+    }
+  }
 
   const onTouchStart = (e: React.TouchEvent) => {
     const startX = e.touches[0].clientX

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -1,7 +1,6 @@
 {
   "slider-layout": {
     "component": "SliderLayout",
-    "composition": "children",
-    "allowed": "*"
+    "composition": "children"
   }
 }


### PR DESCRIPTION
#### What does this PR do?

Refactors a few components and custom hooks from the `slider-layout` internal implementation that prevents it from "flashing" when transitioning from SSR to CSR.

#### How to test it?

Both the Carousel and the Shelf in this workspace were replaced by list blocks using `slider-layout`s.

#### Related to / Depends on

This is related to https://github.com/vtex-apps/product-summary/pull/229 and https://github.com/vtex-apps/store-theme/pull/190 .
