### PR TITLE
Feature/prevent rendering slides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Prevent unvisited slides from rendering, improving performance.
 
 ## [0.8.2] - 2020-02-07
 ### Fixed

--- a/react/components/SliderTrack.tsx
+++ b/react/components/SliderTrack.tsx
@@ -22,9 +22,9 @@ const useSliderVisibility = (currentSlide: number, slidesPerPage: number) => {
   const visitedSlides = useRef<Set<number>>(new Set())
 
   useEffect(() => {
-    Array(slidesPerPage).fill('').forEach((_, i) => {
+    for (let i = 0; i < slidesPerPage; i++) {
       visitedSlides.current.add(currentSlide + i)
-    })
+    }
   }, [currentSlide])
 
   const isItemVisible = (index: number) => isSlideVisible(index, currentSlide, slidesPerPage)

--- a/react/components/SliderTrack.tsx
+++ b/react/components/SliderTrack.tsx
@@ -1,10 +1,40 @@
-import React, { FC } from 'react'
+import React, { FC, useEffect, useRef } from 'react'
 import { useListContext } from 'vtex.list-context'
 import { useCssHandles } from 'vtex.css-handles'
 
 import { useSliderState } from './SliderContext'
 
 const CSS_HANDLES = ['sliderTrack', 'slide', 'slideChildrenContainer']
+
+const isSlideVisible = (
+  index: number,
+  currentSlide: number,
+  slidesToShow: number
+): boolean => {
+  return index >= currentSlide && index < currentSlide + slidesToShow
+}
+
+const useSliderVisibility = (currentSlide: number, slidesPerPage: number) => {
+  /** Keeps track of slides that have been visualised before, to keep
+   * rendering them. We want to keep rendering them because the issue
+   * is mostly rendering slides that might never be viewed; On the other
+   * hand, hiding slides that were visible causes visual glitches */
+  const visitedSlides = useRef<Set<number>>(new Set())
+
+  useEffect(() => {
+    Array(slidesPerPage).fill('').forEach((_, i) => {
+      visitedSlides.current.add(currentSlide + i)
+    })
+  }, [currentSlide])
+
+  const isItemVisible = (index: number) => isSlideVisible(index, currentSlide, slidesPerPage)
+
+  const shouldRenderItem = (index: number) => {
+    return visitedSlides.current.has(index) || isItemVisible(index)
+  }
+
+  return { shouldRenderItem, isItemVisible }
+}
 
 const SliderTrack: FC<{ totalItems: number }> = ({ children, totalItems }) => {
   const {
@@ -16,17 +46,12 @@ const SliderTrack: FC<{ totalItems: number }> = ({ children, totalItems }) => {
     slideTransition: { speed, timing, delay },
   } = useSliderState()
   const handles = useCssHandles(CSS_HANDLES)
+
+  const { shouldRenderItem, isItemVisible } = useSliderVisibility(currentSlide, slidesPerPage)
+
   const { list } = useListContext()
 
   const childrenArray = React.Children.toArray(children).concat(list)
-
-  const isSlideVisible = (
-    index: number,
-    currentSlide: number,
-    slidesToShow: number
-  ): boolean => {
-    return index >= currentSlide && index < currentSlide + slidesToShow
-  }
 
   return (
     <div
@@ -45,30 +70,32 @@ const SliderTrack: FC<{ totalItems: number }> = ({ children, totalItems }) => {
       aria-atomic="false"
       aria-live="polite"
     >
-      {childrenArray.map((child, index) => (
-        <div
-          key={index}
-          className={`flex relative ${handles.slide}`}
-          data-index={index}
-          style={{
-            width: `${slideWidth}%`,
-          }}
-          aria-hidden={
-            isSlideVisible(index, currentSlide, slidesPerPage)
-              ? 'false'
-              : 'true'
-          }
-          role="group"
-          aria-roledescription="slide"
-          aria-label={`${index + 1} of ${totalItems}`}
-        >
+      {childrenArray.map((child, index) => {
+        return (
           <div
-            className={`${handles.slideChildrenContainer} flex justify-center items-center w-100`}
+            key={index}
+            className={`flex relative ${handles.slide}`}
+            data-index={index}
+            style={{
+              width: `${slideWidth}%`,
+            }}
+            aria-hidden={
+              isItemVisible(index)
+                ? 'false'
+                : 'true'
+            }
+            role="group"
+            aria-roledescription="slide"
+            aria-label={`${index + 1} of ${totalItems}`}
           >
-            {child}
+            <div
+              className={`${handles.slideChildrenContainer} flex justify-center items-center w-100`}
+            >
+              {shouldRenderItem(index) ? child : null}
+            </div>
           </div>
-        </div>
-      ))}
+        )
+      })}
     </div>
   )
 }

--- a/react/components/SliderTrack.tsx
+++ b/react/components/SliderTrack.tsx
@@ -15,10 +15,10 @@ const isSlideVisible = (
 }
 
 const useSliderVisibility = (currentSlide: number, slidesPerPage: number) => {
-  /** Keeps track of slides that have been visualised before, to keep
-   * rendering them. We want to keep rendering them because the issue
-   * is mostly rendering slides that might never be viewed; On the other
-   * hand, hiding slides that were visible causes visual glitches */
+  /** Keeps track of slides that have been visualised before.
+   * We want to keep rendering them because the issue is mostly rendering
+   * slides that might never be viewed; On the other hand, hiding slides
+   * that were visible causes visual glitches */
   const visitedSlides = useRef<Set<number>>(new Set())
 
   useEffect(() => {


### PR DESCRIPTION
#### What does this PR do? \*
Prevents unvisited slides from rendering, improving performance.

Before:
<img width="259" alt="Screen Shot 2020-03-05 at 16 32 09" src="https://user-images.githubusercontent.com/5691711/76018851-8b012180-5eff-11ea-9c53-f5b48725dcb3.png">

After:
<img width="188" alt="Screen Shot 2020-03-05 at 16 31 31" src="https://user-images.githubusercontent.com/5691711/76018872-92c0c600-5eff-11ea-8a44-c05bb371bc5c.png">
(dev workspace metrics)

To test, scroll down to the shelf and change the current slide, on mobile and desktop.
https://slideropt--storecomponents.myvtex.com/

#### How to test it? \*

#### Describe alternatives you've considered, if any. \*

<!--- Optional -->

#### Related to / Depends on \*

<!--- Optional -->
