### PR TITLE
Add 'firstVisible' and 'lastVisible' modifiers to 'slider' CSS handle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
-- New CSS Handles `firstVisible` and `lastVisible`
+- Modifiers `firstVisible` and `lastVisible` for the `slide` CSS Handles 
 
 ## [0.11.0] - 2020-03-11
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- New CSS Handles `firstVisible` and `lastVisible`
+
 ## [0.11.0] - 2020-03-11
 ### Added
 - New CSS Handle `paginationDot--isActive`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -75,6 +75,8 @@ In order to apply CSS customizations in this and other blocks, follow the instru
 | `sliderTrackContainer`    |
 | `sliderTrack`             |
 | `slide`                   |
+| `slide--firstVisible`     |
+| `slide--lastVisible`      |
 | `slideChildrenContainer`  |
 | `sliderLeftArrow`         |
 | `sliderRightArrow`        |
@@ -82,8 +84,6 @@ In order to apply CSS customizations in this and other blocks, follow the instru
 | `paginationDotsContainer` |
 | `paginationDot`           |
 | `paginationDot--isActive` |
-| `firstVisible`            |
-| `lastVisible`             |
 
 ## Contributors ✨
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -82,6 +82,8 @@ In order to apply CSS customizations in this and other blocks, follow the instru
 | `paginationDotsContainer` |
 | `paginationDot`           |
 | `paginationDot--isActive` |
+| `firstVisible`            |
+| `lastVisible`             |
 
 ## Contributors ✨
 

--- a/react/components/SliderTrack.tsx
+++ b/react/components/SliderTrack.tsx
@@ -21,7 +21,8 @@ const getFirstOrLastVisible = (
 ) => {
   if (index % slidesPerPage === 0) {
     return handles.firstVisible
-  } else if (((index + 1) % slidesPerPage) === 0) {
+  }
+  if (((index + 1) % slidesPerPage) === 0) {
     return handles.lastVisible
   }
   return ''

--- a/react/components/SliderTrack.tsx
+++ b/react/components/SliderTrack.tsx
@@ -4,11 +4,7 @@ import { useCssHandles, applyModifiers } from 'vtex.css-handles'
 
 import { useSliderState } from './SliderContext'
 
-const CSS_HANDLES = [
-  'sliderTrack',
-  'slide',
-  'slideChildrenContainer',
-]
+const CSS_HANDLES = ['sliderTrack', 'slide', 'slideChildrenContainer']
 
 const isSlideVisible = (
   index: number,

--- a/react/components/SliderTrack.tsx
+++ b/react/components/SliderTrack.tsx
@@ -15,14 +15,15 @@ const isSlideVisible = (
 }
 
 const getFirstOrLastVisible = (slidesPerPage: number, index: number) => {
+  // every multiple of the number of slidesPerPage is a first (e.g. 0,3,6 if slidesPerPage is 3)
   if (index % slidesPerPage === 0) {
     return 'firstVisible'
   }
-  
+  // every slide before  the multiple of the number of slidesPerPage is a last (e.g. 2,5,8 if slidesPerPage is 3)
   if ((index + 1) % slidesPerPage === 0) {
     return 'lastVisible'
   }
-  
+
   return ''
 }
 

--- a/react/components/SliderTrack.tsx
+++ b/react/components/SliderTrack.tsx
@@ -24,9 +24,11 @@ const getFirstOrLastVisible = (slidesPerPage: number, index: number) => {
   if (index % slidesPerPage === 0) {
     return 'firstVisible'
   }
+  
   if ((index + 1) % slidesPerPage === 0) {
     return 'lastVisible'
   }
+  
   return ''
 }
 

--- a/react/components/SliderTrack.tsx
+++ b/react/components/SliderTrack.tsx
@@ -4,7 +4,7 @@ import { useCssHandles } from 'vtex.css-handles'
 
 import { useSliderState } from './SliderContext'
 
-const CSS_HANDLES = ['sliderTrack', 'slide', 'slideChildrenContainer']
+const CSS_HANDLES = ['sliderTrack', 'slide', 'slideChildrenContainer', 'firstVisible', 'lastVisible']
 
 const isSlideVisible = (
   index: number,
@@ -12,6 +12,19 @@ const isSlideVisible = (
   slidesToShow: number
 ): boolean => {
   return index >= currentSlide && index < currentSlide + slidesToShow
+}
+
+const getFirstOrLastVisible = (
+  handles: Record<string,string>,
+  slidesPerPage: number,
+  index: number,
+) => {
+  if (index % slidesPerPage === 0) {
+    return handles.firstVisible
+  } else if (((index + 1) % slidesPerPage) === 0) {
+    return handles.lastVisible
+  }
+  return ''
 }
 
 const useSliderVisibility = (currentSlide: number, slidesPerPage: number) => {
@@ -74,7 +87,7 @@ const SliderTrack: FC<{ totalItems: number }> = ({ children, totalItems }) => {
         return (
           <div
             key={index}
-            className={`flex relative ${handles.slide}`}
+            className={`flex relative ${handles.slide} ${getFirstOrLastVisible(handles, slidesPerPage, index)}`}
             data-index={index}
             style={{
               width: `${slideWidth}%`,

--- a/react/components/SliderTrack.tsx
+++ b/react/components/SliderTrack.tsx
@@ -1,10 +1,16 @@
 import React, { FC, useEffect, useRef } from 'react'
 import { useListContext } from 'vtex.list-context'
-import { useCssHandles } from 'vtex.css-handles'
+import { useCssHandles, applyModifiers } from 'vtex.css-handles'
 
 import { useSliderState } from './SliderContext'
 
-const CSS_HANDLES = ['sliderTrack', 'slide', 'slideChildrenContainer', 'firstVisible', 'lastVisible']
+const CSS_HANDLES = [
+  'sliderTrack',
+  'slide',
+  'slideChildrenContainer',
+  'firstVisible',
+  'lastVisible',
+]
 
 const isSlideVisible = (
   index: number,
@@ -14,16 +20,12 @@ const isSlideVisible = (
   return index >= currentSlide && index < currentSlide + slidesToShow
 }
 
-const getFirstOrLastVisible = (
-  handles: Record<string,string>,
-  slidesPerPage: number,
-  index: number,
-) => {
+const getFirstOrLastVisible = (slidesPerPage: number, index: number) => {
   if (index % slidesPerPage === 0) {
-    return handles.firstVisible
+    return 'firstVisible'
   }
-  if (((index + 1) % slidesPerPage) === 0) {
-    return handles.lastVisible
+  if ((index + 1) % slidesPerPage === 0) {
+    return 'lastVisible'
   }
   return ''
 }
@@ -39,9 +41,10 @@ const useSliderVisibility = (currentSlide: number, slidesPerPage: number) => {
     for (let i = 0; i < slidesPerPage; i++) {
       visitedSlides.current.add(currentSlide + i)
     }
-  }, [currentSlide])
+  }, [currentSlide, slidesPerPage])
 
-  const isItemVisible = (index: number) => isSlideVisible(index, currentSlide, slidesPerPage)
+  const isItemVisible = (index: number) =>
+    isSlideVisible(index, currentSlide, slidesPerPage)
 
   const shouldRenderItem = (index: number) => {
     return visitedSlides.current.has(index) || isItemVisible(index)
@@ -61,7 +64,10 @@ const SliderTrack: FC<{ totalItems: number }> = ({ children, totalItems }) => {
   } = useSliderState()
   const handles = useCssHandles(CSS_HANDLES)
 
-  const { shouldRenderItem, isItemVisible } = useSliderVisibility(currentSlide, slidesPerPage)
+  const { shouldRenderItem, isItemVisible } = useSliderVisibility(
+    currentSlide,
+    slidesPerPage
+  )
 
   const { list } = useListContext()
 
@@ -88,16 +94,15 @@ const SliderTrack: FC<{ totalItems: number }> = ({ children, totalItems }) => {
         return (
           <div
             key={index}
-            className={`flex relative ${handles.slide} ${getFirstOrLastVisible(handles, slidesPerPage, index)}`}
+            className={`${applyModifiers(
+              handles.slide,
+              getFirstOrLastVisible(slidesPerPage, index)
+            )} flex relative`}
             data-index={index}
             style={{
               width: `${slideWidth}%`,
             }}
-            aria-hidden={
-              isItemVisible(index)
-                ? 'false'
-                : 'true'
-            }
+            aria-hidden={isItemVisible(index) ? 'false' : 'true'}
             role="group"
             aria-roledescription="slide"
             aria-label={`${index + 1} of ${totalItems}`}

--- a/react/components/SliderTrack.tsx
+++ b/react/components/SliderTrack.tsx
@@ -8,8 +8,6 @@ const CSS_HANDLES = [
   'sliderTrack',
   'slide',
   'slideChildrenContainer',
-  'firstVisible',
-  'lastVisible',
 ]
 
 const isSlideVisible = (

--- a/react/package.json
+++ b/react/package.json
@@ -19,6 +19,6 @@
     "@types/react": "^16.8.15",
     "@vtex/test-tools": "^0.2.0",
     "prettier": "^1.18.2",
-    "typescript": "3.7.3"
+    "typescript": "3.8.3"
   }
 }

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -4239,10 +4239,10 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-typescript@3.7.3:
-  version "3.7.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.3.tgz#b36840668a16458a7025b9eabfad11b66ab85c69"
-  integrity sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==
+typescript@3.8.3:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
+  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
 
 typescript@^3.3.3333:
   version "3.7.5"


### PR DESCRIPTION
#### What does this PR do? \*

Adds a handle for the first and last visible items on a slider

#### How to test it? \*

Check the handles for every first and last item on a slide

#### Describe alternatives you've considered, if any. \*

I've added this for better control padding between items, but this is not possible since all items in the slide are children of the same parent, hence the last visible is not actually the last in a slide

http://savio--extensions.myvtex.com/