### PR TITLE
Add support for true infinite looping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Infinite loops now happen without "rewinding" effects.
 
 ## [0.11.3] - 2020-07-22
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Changed
+### Fixed
 - Infinite loops now happen without "rewinding" effects.
 
 ## [0.11.3] - 2020-07-22

--- a/react/SliderLayout.tsx
+++ b/react/SliderLayout.tsx
@@ -21,9 +21,15 @@ const SliderLayout: StorefrontFunctionComponent<SliderLayoutProps &
   const list = useListContext()?.list ?? []
   const totalSlides = totalItems ?? React.Children.count(children) + list.length
   const responsiveArrowIconSize = useResponsiveValue(arrowSize)
+  const slides = React.Children.toArray(children).concat(list)
 
   return (
-    <SliderContextProvider totalItems={totalSlides} {...contextProps}>
+    <SliderContextProvider
+      infinite={infinite}
+      slides={slides}
+      totalItems={totalSlides}
+      {...contextProps}
+    >
       <Slider
         infinite={infinite}
         showNavigationArrows={showNavigationArrows}

--- a/react/components/Slider.tsx
+++ b/react/components/Slider.tsx
@@ -82,7 +82,9 @@ const Slider: FC<Props> = ({
         }`}
         ref={containerRef}
       >
-        <SliderTrack totalItems={totalItems}>{children}</SliderTrack>
+        <SliderTrack infinite={infinite} totalItems={totalItems}>
+          {children}
+        </SliderTrack>
       </div>
       {shouldShowArrows && shouldUsePagination && (
         <Fragment>

--- a/react/components/SliderTrack.tsx
+++ b/react/components/SliderTrack.tsx
@@ -178,7 +178,11 @@ const SliderTrack: FC<Props> = ({ totalItems, infinite }) => {
               handles.slide,
               getFirstOrLastVisible(slidesPerPage, adjustedIndex)
             )} flex relative`}
-            data-index={adjustedIndex}
+            data-index={
+              adjustedIndex >= 0 && adjustedIndex < totalItems
+                ? adjustedIndex + 1
+                : undefined
+            }
             style={{
               width: `${slideWidth}%`,
             }}

--- a/react/hooks/useSliderControls.ts
+++ b/react/hooks/useSliderControls.ts
@@ -4,9 +4,9 @@ export const useSliderControls = (infinite: boolean) => {
   const {
     currentSlide,
     slidesPerPage,
-    slideWidth,
     totalItems,
     navigationStep,
+    transformMap,
   } = useSliderState()
   const dispatch = useSliderDispatch()
 
@@ -20,15 +20,14 @@ export const useSliderControls = (infinite: boolean) => {
     if (nextMaximumSlides >= 0) {
       /** Have more slides hidden on left */
       nextSlide = nextMaximumSlides
-      nextTransformValue = -(slideWidth * nextSlide)
+      nextTransformValue = transformMap[nextSlide]
     } else if (nextMaximumSlides < 0 && currentSlide !== 0) {
       /** Prevent overslide */
       nextSlide = 0
       nextTransformValue = 0
     } else if (infinite) {
-      /** If reach start, go to last slide */
       nextSlide = totalItems - slidesPerPage
-      nextTransformValue = -(slideWidth * nextSlide)
+      nextTransformValue = transformMap[nextSlide]
     }
 
     dispatch({
@@ -41,8 +40,8 @@ export const useSliderControls = (infinite: boolean) => {
   }
 
   const goForward = (step?: number) => {
-    let nextSlides = 0
-    let nextPosition = 0
+    let nextSlide = 0
+    let nextTransformValue = 0
     const activeNavigationStep = step ?? navigationStep
 
     const nextMaximumSlides =
@@ -50,26 +49,25 @@ export const useSliderControls = (infinite: boolean) => {
 
     if (nextMaximumSlides <= totalItems) {
       /** Have more slides hidden on right */
-      nextSlides = currentSlide + activeNavigationStep
-      nextPosition = -(slideWidth * nextSlides)
+      nextSlide = currentSlide + activeNavigationStep
+      nextTransformValue = transformMap[nextSlide]
     } else if (
       nextMaximumSlides > totalItems &&
       currentSlide !== totalItems - slidesPerPage
     ) {
       /** Prevent overslide */
-      nextSlides = totalItems - slidesPerPage
-      nextPosition = -(slideWidth * nextSlides)
+      nextSlide = totalItems - slidesPerPage
+      nextTransformValue = transformMap[nextSlide]
     } else if (infinite) {
-      /** if reach end go to first slide */
-      nextSlides = 0
-      nextPosition = -(slideWidth * nextSlides)
+      nextSlide = currentSlide + activeNavigationStep
+      nextTransformValue = transformMap[nextSlide]
     }
 
     dispatch({
       type: 'SLIDE',
       payload: {
-        transform: nextPosition,
-        currentSlide: nextSlides,
+        transform: nextTransformValue,
+        currentSlide: nextSlide,
       },
     })
   }

--- a/react/hooks/useSliderControls.ts
+++ b/react/hooks/useSliderControls.ts
@@ -26,7 +26,7 @@ export const useSliderControls = (infinite: boolean) => {
       nextSlide = 0
       nextTransformValue = 0
     } else if (infinite) {
-      nextSlide = totalItems - slidesPerPage
+      nextSlide = nextMaximumSlides
       nextTransformValue = transformMap[nextSlide]
     }
 

--- a/react/hooks/useTouchHandlers.ts
+++ b/react/hooks/useTouchHandlers.ts
@@ -22,10 +22,9 @@ export const useTouchHandlers = ({ infinite }: { infinite: boolean }) => {
 
   const onTouchMove = (e: React.TouchEvent) => {
     const currentX = e.touches[0].clientX
+    const touchMoveDelta = currentX - touchState.touchStartX
 
-    const newTransform =
-      touchState.touchInitialTransform +
-      (currentX - touchState.touchStartX) / 25
+    const newTransform = touchState.touchInitialTransform + touchMoveDelta / 25
 
     dispatch({
       type: 'TOUCH',


### PR DESCRIPTION
#### What problem is this solving?

Our current `infinite` slider behavior did not match the expectations of most of our clients since users would see a "rewind" effect as they reached the slider's end. Here's a demo of our current implementation:

![slider-layout-loop-before](https://user-images.githubusercontent.com/27777263/88206984-81195a00-cc25-11ea-83be-253e0cbdab1f.gif)

With this PR, we're adding support for truly infinite looping, without the rewinding effect. (Not going to show you just yet 🤫 ).

#### How to test it?

Go into this very creatively named [Workspace](https://sliderlayout--storecomponents.myvtex.com/) and play with the shelf, you can go to the right or to the left as much as you want and you should never see that rewind effect again.

#### Screenshots or example usage:

Okay, now we're showing you. This is an example of clicking in the right arrow a bunch of times.

![slider-layout-loop-right-after](https://user-images.githubusercontent.com/27777263/88208386-84154a00-cc27-11ea-8c6d-549329152909.gif)

The gif quality is very low (and it's running on 10 FPS), because of GitHub's size limit... Please go to the demo workspace and see it for yourself :)

#### How does this PR make you feel? [:link:](http://giphy.com/)

I could not get the GIF to show up... no idea why 😢 
 
This is the link: https://media.giphy.com/media/bXvwCQglnTGKs/giphy.gif

![giphy](https://user-images.githubusercontent.com/27777263/88209934-c770b800-cc29-11ea-8160-7ea95ec19e29.gif)

