### PR TITLE
Fix SliderTrack width calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `SliderTrack` component miscalculating its own width.
 
-## [0.11.4] - 2020-07-29
+## [0.11.4] - 2020-07-29 [YANKED]
 ### Fixed
 - Infinite loops now happen without "rewinding" effects.
 

--- a/react/components/SliderTrack.tsx
+++ b/react/components/SliderTrack.tsx
@@ -116,7 +116,7 @@ const SliderTrack: FC<Props> = ({ totalItems, infinite }) => {
   )
 
   const trackWidth =
-    slidesPerPage < totalItems
+    slidesPerPage <= totalItems
       ? `${(slides.length * 100) / slidesPerPage}%`
       : '100%'
 


### PR DESCRIPTION
#### What problem is this solving?

There was a miscalculation caused by the latest release https://github.com/vtex-apps/slider-layout/pull/31 in how the `SliderTrack` component determined its own width. This is a sneak one, it only affected sliders which had a `number of items <= itemsPerPage`.

#### How to test it?

This [Workspace](https://victormiranda--carrefourbrfood.myvtex.com/) from Carrefour has a surprisingly high amount of slides that fall into that category... they were also the ones to spot the issue 😅. 

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/Vgldw2H2uRLRXTtWhS/giphy.gif)
