### PR TITLE
Fix 'slidesPerPage' context variable calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `slidesPerPage` miscalculation in situations where the total number of slides to render where less than the value from `itemsPerPage` for the current device.
 
-## [0.11.5] - 2020-07-30
+## [0.11.5] - 2020-07-30 [YANKED]
 ### Fixed
 - `SliderTrack` component miscalculating its own width.
 

--- a/react/components/SliderContext.tsx
+++ b/react/components/SliderContext.tsx
@@ -150,11 +150,14 @@ const SliderContextProvider: FC<SliderContextProps> = ({
   const resolvedNavigationStep =
     navigationStep === 'page' ? itemsPerPage[device] : navigationStep
 
+  const resolvedSlidesPerPage =
+    totalItems <= itemsPerPage[device] ? totalItems : itemsPerPage[device]
+
   const postRenderedSlides = infinite
-    ? slides.slice(0, itemsPerPage[device])
+    ? slides.slice(0, resolvedSlidesPerPage)
     : []
   const preRenderedSlides = infinite
-    ? slides.slice(slides.length - itemsPerPage[device])
+    ? slides.slice(slides.length - resolvedSlidesPerPage)
     : []
   const newSlides = preRenderedSlides.concat(slides, postRenderedSlides)
 
@@ -164,15 +167,15 @@ const SliderContextProvider: FC<SliderContextProps> = ({
     const currentMap: Record<number, number> = {}
 
     newSlides.forEach((_, idx) => {
-      currentMap[idx - itemsPerPage[device]] = -(slideWidth * idx)
+      currentMap[idx - resolvedSlidesPerPage] = -(slideWidth * idx)
     })
 
     return currentMap
-  }, [device, slideWidth, newSlides, itemsPerPage])
+  }, [slideWidth, newSlides, resolvedSlidesPerPage])
 
   const [state, dispatch] = useReducer(sliderContextReducer, {
     slideWidth,
-    slidesPerPage: itemsPerPage[device],
+    slidesPerPage: resolvedSlidesPerPage,
     currentSlide: 0,
     transform: transformMap[0],
     transformMap,

--- a/react/hooks/useScreenResize.ts
+++ b/react/hooks/useScreenResize.ts
@@ -8,20 +8,25 @@ export const useScreenResize = (infinite: boolean) => {
     navigationStep,
     isPageNavigationStep,
     itemsPerPage,
+    totalItems,
   } = useSliderState()
   const { device } = useDevice()
   const dispatch = useSliderDispatch()
 
   useEffect(() => {
+    const newSlidesPerPage =
+      totalItems <= itemsPerPage[device] ? totalItems : itemsPerPage[device]
+    const newNavigationStep = isPageNavigationStep
+      ? newSlidesPerPage
+      : navigationStep
+
     const setNewState = (shouldCorrectItemPosition: boolean) => {
       dispatch({
         type: 'ADJUST_ON_RESIZE',
         payload: {
           shouldCorrectItemPosition,
-          slidesPerPage: itemsPerPage[device],
-          navigationStep: isPageNavigationStep
-            ? itemsPerPage[device]
-            : navigationStep,
+          slidesPerPage: newSlidesPerPage,
+          navigationStep: newNavigationStep,
         },
       })
     }
@@ -35,6 +40,7 @@ export const useScreenResize = (infinite: boolean) => {
   }, [
     infinite,
     dispatch,
+    totalItems,
     itemsPerPage,
     device,
     isPageNavigationStep,


### PR DESCRIPTION
#### What problem is this solving?

There is a problem in the way we used to calculate the value for `slidesPerPage` context variable, now that we're supporting infinite loops. We would always update this variable based on the `itemsPerPage` prop value for the device the `slider` is being rendered, but this is not valid anymore. This means we did not take into account the cases where users would use a `slider-layout` with a total number of items that are less then what they've set for the current device in the `itemsPerPage` prop.

Anyway, this miscalculation was causing the `transformMap` context variable to be initialized with incorrect values, which in turn caused the whole `slider-layout` to be in an impossible state, resulting in no slides showing up whatsoever.

#### How to test it?

Not messing around anymore! Here are a few accounts in which this was tested:

- [Miriade IT](https://victormiranda--miriadeit.myvtex.com/?__bindingAddress=www.miriade.com/it). They've got a lot of sliders on their home page. Including a few ones that are inside a `tab-layout`, pay special attention to those.
- [Store Components](https://victormiranda--storecomponents.myvtex.com/), this one just has to be here, right? 😂 
- [Carrefour BR](https://victormiranda--carrefourbrfood.myvtex.com/), they also have a lot of sliders that fall into the category where things would not work so great... even though everything was fine in this workspace already. #32 was made based on their bug report.
- [Tack Of The Day](https://victormiranda--tackoftheday.myvtex.com/), I don't know, just to be sure 😅 .
- [Equishopper](https://victormiranda--equishopper.myvtex.com/), yep, another store that sells things for horses 😂 .

#### Screenshots or example usage:

This slider below received the following `itemsPerPage` prop:

```json
{
  "itemsPerPage": {
    "desktop": 5,
    "tablet": 3,
    "phone": 2,
  }
}
```

and as you can see in the image, there are only 4 items being rendered, and they're rendered just fine 😄 

<img width="1475" alt="Screen Shot 2020-07-31 at 10 45 38" src="https://user-images.githubusercontent.com/27777263/89041271-79d80780-d31b-11ea-9345-ac4071bf4430.png">

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/IcjOuCcgUBLcVTrzMj/giphy.gif)
