### PR TITLE
Create a new SliderLayoutGroup component and 'slider-layout-group' interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- New `SliderLayoutGroup` component and its `slider-layout-group` interface.
 
 ## [0.12.0] - 2020-08-06
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -102,9 +102,9 @@ Now, you are able to use all blocks exported by the `slider-layout` app. Check o
 
 ## Advanced configurations
 
-The `slider-layout-group` block is responsible for synchronizing a group of `slider-layout` blocks. 
+The `slider-layout-group` block is responsible for synchronizing the slides rendered by each one of the `slider-layout` blocks declared in it. 
 
-The block therefore does not render any specific component on your store's UI and only expects to receive a `children` block list containing the desired `slider-layout` blocks. For example:
+The `slider-layout-group`  therefore does not render any specific component on your store's UI. In turn, it is a logical block that only expects to receive a `children` block list containing the desired `slider-layout` blocks to be rendered. For example:
 
 ```json
 {

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,13 @@ Slider Layout is a flexible solution for building sliders of blocks within VTEX 
 }
 ```
 
+Now, you are able to use all blocks exported by the `slider-layout` app. Check out the full list below:
+
+| Block name     | Description                                     |
+| -------------- | ----------------------------------------------- |
+| `slider-layout` | ![https://img.shields.io/badge/-Mandatory-red](https://img.shields.io/badge/-Mandatory-red) Builds sliders of blocks for your store through its `children` list blocks. |
+| `slider-layout-group` | Enables you to keep a group of `slider-layout` blocks in sync with each other. For more on this, check out the Advanced configurations section below. |
+
 2. Add the `slider-layout` block to your template. For example:
 
 ```json
@@ -93,15 +100,11 @@ Slider Layout is a flexible solution for building sliders of blocks within VTEX 
 | `timeout` | `number` |  Timeout (in `ms`) between each slide. |  `undefined` | 
 | `stopOnHover` | `boolean` |  Whether the auto play should stop when users are hovering the slider (`true`) or not (`false`). | `undefined` |
 
-## `slider-layout-group`
+## Advanced configurations
 
-The `slider-layout-group` block enables you to keep a group of `slider-layout` blocks in sync with each other.
+The `slider-layout-group` block is responsible for synchronizing a group of `slider-layout` blocks. 
 
-Here's an example using three `slider-layout` blocks inside of a `slider-layout-group`. Each of those `slider-layout`s received three `rich-text` blocks to serve as individual slides.
-
-![slider-layout-group demo](https://user-images.githubusercontent.com/27777263/89814281-46665b80-db19-11ea-9ff2-8aff60c72a73.gif)
-
-This block only expects to receive `children`, such as:
+The block therefore does not render any specific component on your store's UI and only expects to receive a `children` block list containing the desired `slider-layout` blocks. For example:
 
 ```json
 {
@@ -115,7 +118,11 @@ This block only expects to receive `children`, such as:
 }
 ```
 
-:information_source: It is **very** important that all `slider-layout` blocks inside a group receive the same configuration props, and differ only in their children. Trying to use `slider-layout` blocks with different configuration, such as each one with a different value for `itemsPerPage`, will result in unexpected behavior and is **not** supported.
+Below, you can find a practical example using three `slider-layout` blocks inside of a `slider-layout-group`. Each of those `slider-layout`s received three `rich-text` blocks as `children` to serve as individual slides:
+
+![slider-layout-group demo](https://user-images.githubusercontent.com/27777263/89814281-46665b80-db19-11ea-9ff2-8aff60c72a73.gif)
+
+:warning: ***All `slider-layout` blocks declared in the `slider-layout-group` must receive the same configuration, meaning the same props and values**. Due to implementation rules, they are only allowed to differ in their `children` block list. Notice the following: declaring `slider-layout` blocks with different configuration will result in unexpected behavior, leading to errors whose support is **not** granted by the VTEX Store Framework team.*
 
 ## Customization
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -91,7 +91,31 @@ Slider Layout is a flexible solution for building sliders of blocks within VTEX 
 | Prop name | Type | Description | Default value |
 | ------- | ------ | -------- | ------------- | 
 | `timeout` | `number` |  Timeout (in `ms`) between each slide. |  `undefined` | 
-| `stopOnHover` | `boolean` |  Whether the auto play should stop when users are hovering the slider (`true`) or not (`false`). | `undefined` | 
+| `stopOnHover` | `boolean` |  Whether the auto play should stop when users are hovering the slider (`true`) or not (`false`). | `undefined` |
+
+## `slider-layout-group`
+
+The `slider-layout-group` block enables you to keep a group of `slider-layout` blocks in sync with each other.
+
+Here's an example using three `slider-layout` blocks inside of a `slider-layout-group`. Each of those `slider-layout`s received three `rich-text` blocks to serve as individual slides.
+
+![slider-layout-group demo](https://user-images.githubusercontent.com/27777263/89814281-46665b80-db19-11ea-9ff2-8aff60c72a73.gif)
+
+This block only expects to receive `children`, such as:
+
+```json
+{
+  "slider-layout-group#test": {
+    "children": [
+      "slider-layout#1",
+      "slider-layout#2",
+      "slider-layout#3"
+    ]
+  }
+}
+```
+
+:information_source: It is **very** important that all `slider-layout` blocks inside a group receive the same configuration props, and differ only in their children. Trying to use `slider-layout` blocks with different configuration, such as each one with a different value for `itemsPerPage`, will result in unexpected behavior and is **not** supported.
 
 ## Customization
 

--- a/react/SliderLayoutGroup.tsx
+++ b/react/SliderLayoutGroup.tsx
@@ -1,14 +1,31 @@
-import * as React from 'react'
+import React, { createContext, useReducer, useContext } from 'react'
 
-const initialState = {
-  currentSlide: 0,
-  transform: null,
+interface State {
+  currentSlide: number
+  transform?: null | number
 }
 
-const SliderGroupStateContext = React.createContext(initialState)
-const SliderGroupDispatchContext = React.createContext(0)
+interface SlideAction {
+  type: 'SLIDE'
+  payload: {
+    currentSlide: number
+    transform?: number
+  }
+}
 
-const reducer = (state, action) => {
+type Action = SlideAction
+type Dispatch = (action: Action) => void
+
+const SliderGroupStateContext = createContext<State | undefined>({
+  currentSlide: 0,
+  transform: null,
+})
+
+const SliderGroupDispatchContext = createContext<Dispatch | undefined>(
+  undefined
+)
+
+const reducer = (state: State, action: Action): State => {
   switch (action.type) {
     case 'SLIDE': {
       return {
@@ -17,22 +34,38 @@ const reducer = (state, action) => {
         transform: action.payload.transform,
       }
     }
+
     default: {
       return state
     }
   }
 }
 
-const SliderLayoutGroup: React.FC = (props) => {
-  const [state, dispatch] = React.useReducer(reducer, initialState)
+const SliderLayoutGroup: React.FC = ({ children }) => {
+  const [state, dispatch] = useReducer(reducer, {
+    currentSlide: 0,
+    transform: null,
+  })
 
   return (
     <SliderGroupStateContext.Provider value={state}>
       <SliderGroupDispatchContext.Provider value={dispatch}>
-        {props.children}
+        {children}
       </SliderGroupDispatchContext.Provider>
     </SliderGroupStateContext.Provider>
   )
+}
+
+export function useSliderGroupState() {
+  const context = useContext(SliderGroupStateContext)
+
+  return context
+}
+
+export function useSliderGroupDispatch() {
+  const context = useContext(SliderGroupDispatchContext)
+
+  return context
 }
 
 export default SliderLayoutGroup

--- a/react/SliderLayoutGroup.tsx
+++ b/react/SliderLayoutGroup.tsx
@@ -3,6 +3,7 @@ import React, { createContext, useReducer, useContext } from 'react'
 interface State {
   currentSlide: number
   transform?: null | number
+  isHovering: boolean
 }
 
 interface SlideAction {
@@ -13,7 +14,14 @@ interface SlideAction {
   }
 }
 
-type Action = SlideAction
+interface HoverAction {
+  type: 'HOVER'
+  payload: {
+    isHovering: boolean
+  }
+}
+
+type Action = SlideAction | HoverAction
 type Dispatch = (action: Action) => void
 
 const SliderGroupStateContext = createContext<State | undefined>(undefined)
@@ -42,6 +50,7 @@ const SliderLayoutGroup: React.FC = ({ children }) => {
   const [state, dispatch] = useReducer(reducer, {
     currentSlide: 0,
     transform: null,
+    isHovering: false,
   })
 
   return (

--- a/react/SliderLayoutGroup.tsx
+++ b/react/SliderLayoutGroup.tsx
@@ -16,10 +16,7 @@ interface SlideAction {
 type Action = SlideAction
 type Dispatch = (action: Action) => void
 
-const SliderGroupStateContext = createContext<State | undefined>({
-  currentSlide: 0,
-  transform: null,
-})
+const SliderGroupStateContext = createContext<State | undefined>(undefined)
 
 const SliderGroupDispatchContext = createContext<Dispatch | undefined>(
   undefined

--- a/react/SliderLayoutGroup.tsx
+++ b/react/SliderLayoutGroup.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react'
+
+const initialState = {
+  currentSlide: 0,
+  transform: null,
+}
+
+const SliderGroupStateContext = React.createContext(initialState)
+const SliderGroupDispatchContext = React.createContext(0)
+
+const reducer = (state, action) => {
+  switch (action.type) {
+    case 'SLIDE': {
+      return {
+        ...state,
+        currentSlide: action.payload.currentSlide,
+        transform: action.payload.transform,
+      }
+    }
+    default: {
+      return state
+    }
+  }
+}
+
+const SliderLayoutGroup: React.FC = (props) => {
+  const [state, dispatch] = React.useReducer(reducer, initialState)
+
+  return (
+    <SliderGroupStateContext.Provider value={state}>
+      <SliderGroupDispatchContext.Provider value={dispatch}>
+        {props.children}
+      </SliderGroupDispatchContext.Provider>
+    </SliderGroupStateContext.Provider>
+  )
+}
+
+export default SliderLayoutGroup

--- a/react/__mocks__/vtex.responsive-values.ts
+++ b/react/__mocks__/vtex.responsive-values.ts
@@ -1,1 +1,2 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const useResponsiveValue = jest.fn((args: any) => args)

--- a/react/__mocks__/vtex.responsive-values.ts
+++ b/react/__mocks__/vtex.responsive-values.ts
@@ -1,1 +1,1 @@
-export const useResponsiveValue = (args: unknown) => args
+export const useResponsiveValue = jest.fn((args: any) => args)

--- a/react/__tests__/SliderGroup.test.tsx
+++ b/react/__tests__/SliderGroup.test.tsx
@@ -1,24 +1,46 @@
 import React from 'react'
-import { render } from '@vtex/test-tools/react'
+import { render, getByLabelText, getByText, fireEvent } from '@vtex/test-tools/react'
+import { useResponsiveValue } from 'vtex.responsive-values'
 
 import SliderLayoutGroup from '../SliderLayoutGroup'
 import SliderLayout from '../SliderLayout'
 
+const mockedUseResponsiveValue = useResponsiveValue as jest.Mock<() => number>
+
+mockedUseResponsiveValue.mockImplementation(() => 1)
+
 test('should move all sliders in a group together', () => {
-  const { debug } = render(
+  const { debug, container } = render(
     <SliderLayoutGroup>
-      <SliderLayout blockClass="slider1">
-        <div>Slider 1 Item 1</div>
-        <div>Slider 1 Item 2</div>
-        <div>Slider 1 Item 3</div>
-      </SliderLayout>
-      <SliderLayout blockClass="slider2">
-        <div>Slider 2 Item 1</div>
-        <div>Slider 2 Item 2</div>
-        <div>Slider 2 Item 3</div>
-      </SliderLayout>
+      <div id="first-slide">
+        <SliderLayout showPaginationDots="never">
+          <div>Slider 1 Item 1</div>
+          <div>Slider 1 Item 2</div>
+          <div>Slider 1 Item 3</div>
+        </SliderLayout>
+      </div>
+      <div id="second-slide">
+        <SliderLayout showPaginationDots="never">
+          <div>Slider 2 Item 1</div>
+          <div>Slider 2 Item 2</div>
+          <div>Slider 2 Item 3</div>
+        </SliderLayout>
+      </div>
     </SliderLayoutGroup>
   )
+
+  const firstSlide = container.querySelector('#first-slide') as HTMLElement
+  const secondSlide = container.querySelector('#second-slide') as HTMLElement
+
+  const nextArrow = getByLabelText(firstSlide, 'Next Slide')
+
+  fireEvent.click(nextArrow)
+
+  const visibleSlideFirstSlider = firstSlide.querySelector('[aria-hidden=false]')
+  const visibleSlideSecondSlider = secondSlide.querySelector('[aria-hidden=false]')
+
+  getByText(visibleSlideFirstSlider, 'Slider 1 Item 2')
+  getByText(visibleSlideSecondSlider, 'Slider 2 Item 2')
 
   debug()
 

--- a/react/__tests__/SliderGroup.test.tsx
+++ b/react/__tests__/SliderGroup.test.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import { render } from '@vtex/test-tools/react'
+
+import SliderLayoutGroup from '../SliderLayoutGroup'
+import SliderLayout from '../SliderLayout'
+
+test('should move all sliders in a group together', () => {
+  const { debug } = render(
+    <SliderLayoutGroup>
+      <SliderLayout blockClass="slider1">
+        <div>Slider 1 Item 1</div>
+        <div>Slider 1 Item 2</div>
+        <div>Slider 1 Item 3</div>
+      </SliderLayout>
+      <SliderLayout blockClass="slider2">
+        <div>Slider 2 Item 1</div>
+        <div>Slider 2 Item 2</div>
+        <div>Slider 2 Item 3</div>
+      </SliderLayout>
+    </SliderLayoutGroup>
+  )
+
+  debug()
+
+  expect(true).toBe(true)
+})

--- a/react/__tests__/SliderLayoutGroup.test.tsx
+++ b/react/__tests__/SliderLayoutGroup.test.tsx
@@ -1,25 +1,30 @@
 import React from 'react'
-import { render, getByLabelText, getByText, fireEvent } from '@vtex/test-tools/react'
+import {
+  render,
+  getByLabelText,
+  getByText,
+  fireEvent,
+} from '@vtex/test-tools/react'
 import { useResponsiveValue } from 'vtex.responsive-values'
 
 import SliderLayoutGroup from '../SliderLayoutGroup'
 import SliderLayout from '../SliderLayout'
 
-const mockedUseResponsiveValue = useResponsiveValue as jest.Mock<() => number>
+const mockedUseResponsiveValue = useResponsiveValue as jest.Mock<number>
 
 mockedUseResponsiveValue.mockImplementation(() => 1)
 
 test('should move all sliders in a group together', () => {
-  const { debug, container } = render(
+  const { container } = render(
     <SliderLayoutGroup>
-      <div id="first-slide">
+      <div id="first-slider">
         <SliderLayout showPaginationDots="never">
           <div>Slider 1 Item 1</div>
           <div>Slider 1 Item 2</div>
           <div>Slider 1 Item 3</div>
         </SliderLayout>
       </div>
-      <div id="second-slide">
+      <div id="second-slider">
         <SliderLayout showPaginationDots="never">
           <div>Slider 2 Item 1</div>
           <div>Slider 2 Item 2</div>
@@ -29,20 +34,27 @@ test('should move all sliders in a group together', () => {
     </SliderLayoutGroup>
   )
 
-  const firstSlide = container.querySelector('#first-slide') as HTMLElement
-  const secondSlide = container.querySelector('#second-slide') as HTMLElement
+  const firstSlider = container.querySelector('#first-slider') as HTMLElement
+  const secondSlider = container.querySelector('#second-slider') as HTMLElement
 
-  const nextArrow = getByLabelText(firstSlide, 'Next Slide')
+  const nextArrow = getByLabelText(firstSlider, 'Next Slide')
 
   fireEvent.click(nextArrow)
 
-  const visibleSlideFirstSlider = firstSlide.querySelector('[aria-hidden=false]')
-  const visibleSlideSecondSlider = secondSlide.querySelector('[aria-hidden=false]')
+  const visibleSlideFirstSlider: HTMLElement | null = firstSlider.querySelector(
+    '[aria-hidden=false]'
+  )
+
+  const visibleSlideSecondSlider: HTMLElement | null = secondSlider.querySelector(
+    '[aria-hidden=false]'
+  )
+
+  if (!visibleSlideFirstSlider || !visibleSlideSecondSlider) {
+    throw new Error('Could not find any visible slides')
+  }
 
   getByText(visibleSlideFirstSlider, 'Slider 1 Item 2')
   getByText(visibleSlideSecondSlider, 'Slider 2 Item 2')
-
-  debug()
 
   expect(true).toBe(true)
 })

--- a/react/__tests__/SliderLayoutGroup.test.tsx
+++ b/react/__tests__/SliderLayoutGroup.test.tsx
@@ -38,14 +38,16 @@ test('should move all sliders in a group together', () => {
   const secondSlider = container.querySelector('#second-slider') as HTMLElement
 
   const nextArrow = getByLabelText(firstSlider, 'Next Slide')
+  const previousArrow = getByLabelText(secondSlider, 'Previous Slide')
 
+  // Go to the right
   fireEvent.click(nextArrow)
 
-  const visibleSlideFirstSlider: HTMLElement | null = firstSlider.querySelector(
+  let visibleSlideFirstSlider: HTMLElement | null = firstSlider.querySelector(
     '[aria-hidden=false]'
   )
 
-  const visibleSlideSecondSlider: HTMLElement | null = secondSlider.querySelector(
+  let visibleSlideSecondSlider: HTMLElement | null = secondSlider.querySelector(
     '[aria-hidden=false]'
   )
 
@@ -53,8 +55,26 @@ test('should move all sliders in a group together', () => {
     throw new Error('Could not find any visible slides')
   }
 
-  getByText(visibleSlideFirstSlider, 'Slider 1 Item 2')
-  getByText(visibleSlideSecondSlider, 'Slider 2 Item 2')
+  let secondSlide1 = getByText(visibleSlideFirstSlider, 'Slider 1 Item 2')
+  let secondSlide2 = getByText(visibleSlideSecondSlider, 'Slider 2 Item 2')
 
-  expect(true).toBe(true)
+  expect(secondSlide1).toBeDefined()
+  expect(secondSlide2).toBeDefined()
+
+  // Go to the left
+  fireEvent.click(previousArrow)
+
+  visibleSlideFirstSlider = firstSlider.querySelector('[aria-hidden=false]')
+
+  visibleSlideSecondSlider = secondSlider.querySelector('[aria-hidden=false]')
+
+  if (!visibleSlideFirstSlider || !visibleSlideSecondSlider) {
+    throw new Error('Could not find any visible slides')
+  }
+
+  secondSlide1 = getByText(visibleSlideFirstSlider, 'Slider 1 Item 1')
+  secondSlide2 = getByText(visibleSlideSecondSlider, 'Slider 2 Item 1')
+
+  expect(secondSlide1).toBeDefined()
+  expect(secondSlide2).toBeDefined()
 })

--- a/react/components/Slider.tsx
+++ b/react/components/Slider.tsx
@@ -20,17 +20,17 @@ const CSS_HANDLES = ['sliderLayoutContainer', 'sliderTrackContainer'] as const
 const Slider: FC<Props> = ({
   children,
   totalItems,
-  infinite,
+  infinite = false,
   showNavigationArrows,
   showPaginationDots,
-  usePagination: shouldUsePagination,
+  usePagination: shouldUsePagination = true,
   arrowSize,
   fullWidth,
   itemsPerPage,
 }) => {
   const handles = useCssHandles(CSS_HANDLES)
   const { isMobile } = useDevice()
-  const { label, slidesPerPage } = useSliderState()
+  const { label = 'slider', slidesPerPage } = useSliderState()
   const containerRef = useRef<HTMLDivElement>(null)
   const controls = `${label
     .toLowerCase()

--- a/react/components/SliderContext.tsx
+++ b/react/components/SliderContext.tsx
@@ -84,6 +84,7 @@ interface State extends SliderLayoutProps {
   useSlidingTransitionEffect: boolean
   transformMap: Record<number, number>
   slides: Array<Exclude<ReactNode, boolean | null | undefined>>
+  slideTransition: Exclude<SliderLayoutProps['slideTransition'], undefined>
 }
 
 interface SliderContextProps extends SliderLayoutProps {

--- a/react/components/SliderTrack.tsx
+++ b/react/components/SliderTrack.tsx
@@ -2,6 +2,7 @@ import React, { FC, useEffect, useRef } from 'react'
 import { useCssHandles, applyModifiers } from 'vtex.css-handles'
 
 import { useSliderState, useSliderDispatch } from './SliderContext'
+import { useSliderGroupDispatch } from '../SliderLayoutGroup'
 
 const CSS_HANDLES = ['sliderTrack', 'slide', 'slideChildrenContainer'] as const
 
@@ -110,6 +111,7 @@ const SliderTrack: FC<Props> = ({ totalItems, infinite, usePagination }) => {
   } = useSliderState()
 
   const dispatch = useSliderDispatch()
+  const groupDispatch = useSliderGroupDispatch()
   const handles = useCssHandles(CSS_HANDLES)
 
   const { shouldRenderItem, isItemVisible } = useSliderVisibility(
@@ -147,11 +149,22 @@ const SliderTrack: FC<Props> = ({ totalItems, infinite, usePagination }) => {
               transform: transformMap[0],
             },
           })
+          groupDispatch?.({
+            type: 'SLIDE',
+            payload: { currentSlide: 0, transform: transformMap[0] },
+          })
         }
 
         if (currentSlide < 0) {
           dispatch({
             type: 'ADJUST_CURRENT_SLIDE',
+            payload: {
+              currentSlide: totalItems - slidesPerPage,
+              transform: transformMap[totalItems - slidesPerPage],
+            },
+          })
+          groupDispatch?.({
+            type: 'SLIDE',
             payload: {
               currentSlide: totalItems - slidesPerPage,
               transform: transformMap[totalItems - slidesPerPage],

--- a/react/components/SliderTrack.tsx
+++ b/react/components/SliderTrack.tsx
@@ -43,7 +43,7 @@ const resolveAriaAttributes = (
   }
 
   return {
-    'aria-hidden': visible,
+    'aria-hidden': !visible,
     role: 'group',
     'aria-roledescription': 'slide',
     'aria-label': `${index + 1} of ${totalItems}`,

--- a/react/components/SliderTrack.tsx
+++ b/react/components/SliderTrack.tsx
@@ -130,8 +130,7 @@ const SliderTrack: FC<Props> = ({ totalItems, infinite, usePagination }) => {
         transition:
           isOnTouchMove || !useSlidingTransitionEffect
             ? undefined
-            : `transform ${speed}ms ${timing}`,
-        transitionDelay: `${delay}ms`,
+            : `transform ${speed}ms ${timing} ${delay}ms`,
         transform: `translate3d(${
           isOnTouchMove ? transform : transformMap[currentSlide]
         }%, 0, 0)`,

--- a/react/hooks/useHovering.ts
+++ b/react/hooks/useHovering.ts
@@ -1,16 +1,32 @@
 import { useState, useEffect } from 'react'
 
+import {
+  useSliderGroupState,
+  useSliderGroupDispatch,
+} from '../SliderLayoutGroup'
+
 /**
  * Hook that returns the hover state of a passed ref
  * @param ref React ref
  */
 const useHovering = (ref: React.RefObject<HTMLDivElement>) => {
   const [isHovering, setHovering] = useState(false)
-
-  const onMouseEnter = () => setHovering(true)
-  const onMouseLeave = () => setHovering(false)
+  const groupState = useSliderGroupState()
+  const groupDispatch = useSliderGroupDispatch()
 
   useEffect(() => {
+    const onMouseEnter = () => {
+      groupDispatch?.({ type: 'HOVER', payload: { isHovering: true } })
+
+      setHovering(true)
+    }
+
+    const onMouseLeave = () => {
+      groupDispatch?.({ type: 'HOVER', payload: { isHovering: false } })
+
+      setHovering(false)
+    }
+
     if (ref?.current) {
       ref.current.addEventListener('mouseenter', onMouseEnter)
       ref.current.addEventListener('mouseleave', onMouseLeave)
@@ -24,7 +40,11 @@ const useHovering = (ref: React.RefObject<HTMLDivElement>) => {
         current.removeEventListener('mouseleave', onMouseLeave)
       }
     }
-  }, [ref])
+  }, [ref, groupDispatch])
+
+  if (groupState?.isHovering) {
+    return { isHovering: true }
+  }
 
   return { isHovering }
 }

--- a/react/hooks/useSliderControls.ts
+++ b/react/hooks/useSliderControls.ts
@@ -1,4 +1,5 @@
 import { useSliderDispatch, useSliderState } from '../components/SliderContext'
+import { useSliderGroupDispatch } from '../SliderLayoutGroup'
 
 export const useSliderControls = (infinite: boolean) => {
   const {
@@ -10,6 +11,7 @@ export const useSliderControls = (infinite: boolean) => {
   } = useSliderState()
 
   const dispatch = useSliderDispatch()
+  const groupDispatch = useSliderGroupDispatch()
 
   const goBack = (step?: number) => {
     let nextSlide = 0
@@ -23,12 +25,22 @@ export const useSliderControls = (infinite: boolean) => {
       nextSlide = nextMaximumSlides
       nextTransformValue = transformMap[nextSlide]
     } else if (nextMaximumSlides < 0 && currentSlide !== 0) {
-      /** Prevent overslide */
+      /** Prevent over-slide */
       nextSlide = 0
       nextTransformValue = 0
     } else if (infinite) {
       nextSlide = nextMaximumSlides
       nextTransformValue = transformMap[nextSlide]
+    }
+
+    if (groupDispatch) {
+      groupDispatch({
+        type: 'SLIDE',
+        payload: {
+          currentSlide: nextSlide,
+          transform: nextTransformValue,
+        },
+      })
     }
 
     dispatch({
@@ -62,6 +74,16 @@ export const useSliderControls = (infinite: boolean) => {
     } else if (infinite) {
       nextSlide = currentSlide + activeNavigationStep
       nextTransformValue = transformMap[nextSlide]
+    }
+
+    if (groupDispatch) {
+      groupDispatch({
+        type: 'SLIDE',
+        payload: {
+          currentSlide: nextSlide,
+          transform: nextTransformValue,
+        },
+      })
     }
 
     dispatch({

--- a/react/typings/globals.d.ts
+++ b/react/typings/globals.d.ts
@@ -9,18 +9,18 @@ declare global {
   }
 
   interface SliderLayoutSiteEditorProps {
-    infinite: boolean
-    showNavigationArrows: 'mobileOnly' | 'desktopOnly' | 'always' | 'never'
-    showPaginationDots: 'mobileOnly' | 'desktopOnly' | 'always' | 'never'
-    usePagination: boolean
-    fullWidth: boolean
-    arrowSize: MaybeResponsiveValue<number>
+    infinite?: boolean
+    showNavigationArrows?: 'mobileOnly' | 'desktopOnly' | 'always' | 'never'
+    showPaginationDots?: 'mobileOnly' | 'desktopOnly' | 'always' | 'never'
+    usePagination?: boolean
+    fullWidth?: boolean
+    arrowSize?: MaybeResponsiveValue<number>
   }
 
   interface SliderLayoutProps {
     totalItems?: number
-    label: string
-    slideTransition: {
+    label?: string
+    slideTransition?: {
       /** Transition speed in ms */
       speed: number
       /** Transition delay in ms */
@@ -32,7 +32,7 @@ declare global {
       timeout: number
       stopOnHover?: boolean
     }
-    navigationStep: number | 'page'
-    itemsPerPage: MaybeResponsiveValue<number>
+    navigationStep?: number | 'page'
+    itemsPerPage?: MaybeResponsiveValue<number>
   }
 }

--- a/react/typings/vtex.store-icons.d.ts
+++ b/react/typings/vtex.store-icons.d.ts
@@ -1,5 +1,4 @@
-import { ReactElement } from 'react'
-
 declare module 'vtex.store-icons' {
-  export const IconCaret: ReactElement
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  export const IconCaret: any
 }

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -5,5 +5,9 @@
     "content": {
       "$ref": "#/definitions/SliderLayout"
     }
+  },
+  "slider-layout-group": {
+    "component": "SliderLayoutGroup",
+    "composition": "children"
   }
 }


### PR DESCRIPTION
#### What problem is this solving?

This should enable users to use multiple `slider-layout`s within a group and control them all at the same time.

#### How to test it?

Go to [Workspace](https://victormiranda--storecomponents.myvtex.com/) and play with the three `slider-layout`s just below the Highlights row. You should be able to control all three sliders at once.

#### Screenshots or example usage:

![Aug-10-2020 14-52-36](https://user-images.githubusercontent.com/27777263/89814281-46665b80-db19-11ea-9ff2-8aff60c72a73.gif)

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/3oxHQpeBNp2q3OIcVy/giphy.gif)
