### PR TITLE
Fix incorrect transform values being set by 'ADJUST_ON_RESIZE' reducer action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `ADJUST_ON_RESIZE` reducer action setting `transform` to incorrect values, not based on `transformMap`.
 
 ## [0.13.0] - 2020-08-12
 ### Added

--- a/react/components/SliderContext.tsx
+++ b/react/components/SliderContext.tsx
@@ -116,7 +116,7 @@ function sliderContextReducer(state: State, action: Action): State {
         slidesPerPage: action.payload.slidesPerPage,
         navigationStep: action.payload.navigationStep,
         transform: action.payload.shouldCorrectItemPosition
-          ? -state.slideWidth * state.currentSlide
+          ? state.transformMap[state.currentSlide]
           : state.transform,
       }
 
@@ -225,10 +225,8 @@ const SliderContextProvider: FC<SliderContextProps> = ({
   ])
 
   const initialTransform = useMemo(
-    () =>
-      sliderGroupState?.transform ??
-      transformMap[sliderGroupState?.currentSlide ?? 0],
-    [sliderGroupState, transformMap]
+    () => sliderGroupState?.transform ?? transformMap[initialSlide],
+    [transformMap, initialSlide, sliderGroupState]
   )
 
   const [state, dispatch] = useReducer(sliderContextReducer, {


### PR DESCRIPTION
#### What problem is this solving?

There is an issue with how the `ADJUST_ON_RESIZE` reducer action updates the context's value for the `transform` property, which resulted in strange behaviors upon touch interactions.

What this PR does is change the reducer's code that handles that action so that the `transform` value is updated based on values from `transformMap`.

The visual problem caused by this can be seen in this Loom video recorded by @klzns 

https://www.loom.com/share/e8d0e520e3784ff99ae8277e1a4f575f

You can see that the `transform` value is updated in a very strange way once a user touches it, causing the slider's state to become inconsistent.

#### How to test it?

Go to this [Workspace](https://victormiranda--storekimbo.myvtex.com/?__bindingAddress=www.kimbo.it/), and check out the behavior upon touch interaction in the sliders. They should be working just fine, with no weird responses :)

**Note:** Don't forget to refresh the page once you've entered Chrome's device simulator, since there are components in this store that will not be rendered correctly if you just resize the page since the user agent would not be updated.

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/3orieUe6ejxSFxYCXe/giphy.gif)
