### PR TITLE
Support for dynamic slider-layouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Proper support for dynamic `slider-layout`s.
 
 ## [0.13.2] - 2020-08-19
 ### Added

--- a/react/components/SliderContext.tsx
+++ b/react/components/SliderContext.tsx
@@ -61,6 +61,9 @@ interface AdjustContextValuesAction {
     transformMap: State['transformMap']
     slideWidth: State['slideWidth']
     newSlides: State['slides']
+    slidesPerPage: State['slidesPerPage']
+    transform: State['transform']
+    navigationStep: State['navigationStep']
   }
 }
 
@@ -162,6 +165,9 @@ function sliderContextReducer(state: State, action: Action): State {
         transformMap: action.payload.transformMap,
         slideWidth: action.payload.slideWidth,
         slides: action.payload.newSlides,
+        slidesPerPage: action.payload.slidesPerPage,
+        transform: action.payload.transform,
+        navigationStep: action.payload.navigationStep,
       }
 
     default:
@@ -254,6 +260,9 @@ const SliderContextProvider: FC<SliderContextProps> = ({
         transformMap,
         newSlides,
         slideWidth,
+        slidesPerPage: resolvedSlidesPerPage,
+        transform: transformMap[0],
+        navigationStep: resolvedNavigationStep,
       },
     })
     setPrevItemsPerPage(itemsPerPage)

--- a/react/components/SliderContext.tsx
+++ b/react/components/SliderContext.tsx
@@ -64,6 +64,7 @@ interface AdjustContextValuesAction {
     slidesPerPage: State['slidesPerPage']
     transform: State['transform']
     navigationStep: State['navigationStep']
+    totalItems: State['totalItems']
   }
 }
 
@@ -168,6 +169,7 @@ function sliderContextReducer(state: State, action: Action): State {
         slidesPerPage: action.payload.slidesPerPage,
         transform: action.payload.transform,
         navigationStep: action.payload.navigationStep,
+        totalItems: action.payload.totalItems,
       }
 
     default:
@@ -192,9 +194,14 @@ const SliderContextProvider: FC<SliderContextProps> = ({
 }) => {
   const sliderGroupState = useSliderGroupState()
 
-  const [prevItemsPerPage, setPrevItemsPerPage] = useState<
-    SliderContextProps['itemsPerPage']
-  >(null)
+  // This enables us to support dynamic slider-layouts
+  const [prevProps, setPrevProps] = useState<{
+    itemsPerPage: SliderContextProps['itemsPerPage'] | null
+    totalItems: SliderContextProps['totalItems'] | null
+  }>({
+    itemsPerPage: null,
+    totalItems: null,
+  })
 
   const resolvedNavigationStep =
     navigationStep === 'page' ? itemsPerPage : navigationStep
@@ -253,7 +260,10 @@ const SliderContextProvider: FC<SliderContextProps> = ({
     useSlidingTransitionEffect: false,
   })
 
-  if (itemsPerPage !== prevItemsPerPage) {
+  if (
+    itemsPerPage !== prevProps.itemsPerPage ||
+    totalItems !== prevProps.totalItems
+  ) {
     dispatch({
       type: 'ADJUST_CONTEXT_VALUES',
       payload: {
@@ -261,11 +271,12 @@ const SliderContextProvider: FC<SliderContextProps> = ({
         newSlides,
         slideWidth,
         slidesPerPage: resolvedSlidesPerPage,
-        transform: transformMap[0],
+        transform: transformMap[state.currentSlide],
         navigationStep: resolvedNavigationStep,
+        totalItems,
       },
     })
-    setPrevItemsPerPage(itemsPerPage)
+    setPrevProps({ itemsPerPage, totalItems })
   }
 
   if (


### PR DESCRIPTION
#### What problem is this solving?

The `slider-layout` doesn't behave as expected when users try to add or remove slides from it dynamically, since the values store in `SliderContext` would become outdated. This would cause the slider to be unable to adapt to its new content. 

This is a rebase of #39 from @Jayendra88, with a few adjustments to make it work with the new `slider-layout` code.

#### How to test it?

Go into this [Workspace](https://demo--biscoindqa.myvtex.com/electronic-hardware) provided by @Jayendra88 and select some products to be compared.

#### Screenshots or example usage:

Here's how the slider looks while comparing products

![image](https://user-images.githubusercontent.com/2637457/89862259-32783380-dbc5-11ea-8223-0493d959ed15.png)

#### Related to / Depends on

#39.

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/D3y1KbfTrSuha/giphy.gif)
