### PR TITLE
Fix re-render on children update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Slides not re-rendering on prop change
 
 ## [0.15.0] - 2020-08-24
 ### Added

--- a/react/SliderLayout.tsx
+++ b/react/SliderLayout.tsx
@@ -36,7 +36,6 @@ const SliderLayout: StorefrontFunctionComponent<SliderLayoutProps &
   return (
     <SliderContextProvider
       infinite={infinite}
-      slides={slides}
       totalItems={totalSlides}
       itemsPerPage={responsiveItemsPerPage}
       centerMode={responsiveCenterMode}
@@ -53,7 +52,7 @@ const SliderLayout: StorefrontFunctionComponent<SliderLayoutProps &
         arrowSize={responsiveArrowIconSize}
         itemsPerPage={responsiveItemsPerPage}
       >
-        {children}
+        {slides}
       </Slider>
     </SliderContextProvider>
   )

--- a/react/__fixtures__/SliderStateContext.tsx
+++ b/react/__fixtures__/SliderStateContext.tsx
@@ -1,5 +1,18 @@
 import React from 'react'
 
+export const mockInitialSlides = [
+  <div key={1}>I am a slide. My index is 1</div>,
+  <div key={2}>I am a slide. My index is 2</div>,
+  <div key={3}>I am a slide. My index is 3</div>,
+  <div key={4}>I am a slide. My index is 4</div>,
+  <div key={5}>I am a slide. My index is 5</div>,
+  <div key={6}>I am a slide. My index is 6</div>,
+  <div key={7}>I am a slide. My index is 7</div>,
+  <div key={8}>I am a slide. My index is 8</div>,
+  <div key={9}>I am a slide. My index is 9</div>,
+  <div key={10}>I am a slide. My index is 10</div>,
+]
+
 export const mockInitialInfiniteSliderState = {
   slideWidth: 5,
   slidesPerPage: 5,
@@ -27,28 +40,6 @@ export const mockInitialInfiniteSliderState = {
     '-2': -15,
     '-1': -20,
   },
-  slides: [
-    <div key={-1}>I am a slide. My index is -1</div>,
-    <div key={-2}>I am a slide. My index is -2</div>,
-    <div key={-3}>I am a slide. My index is -3</div>,
-    <div key={-4}>I am a slide. My index is -4</div>,
-    <div key={-5}>I am a slide. My index is -5</div>,
-    <div key={1}>I am a slide. My index is 1</div>,
-    <div key={2}>I am a slide. My index is 2</div>,
-    <div key={3}>I am a slide. My index is 3</div>,
-    <div key={4}>I am a slide. My index is 4</div>,
-    <div key={5}>I am a slide. My index is 5</div>,
-    <div key={6}>I am a slide. My index is 6</div>,
-    <div key={7}>I am a slide. My index is 7</div>,
-    <div key={8}>I am a slide. My index is 8</div>,
-    <div key={9}>I am a slide. My index is 9</div>,
-    <div key={10}>I am a slide. My index is 10</div>,
-    <div key={11}>I am a slide. My index is 11</div>,
-    <div key={12}>I am a slide. My index is 12</div>,
-    <div key={13}>I am a slide. My index is 13</div>,
-    <div key={14}>I am a slide. My index is 14</div>,
-    <div key={15}>I am a slide. My index is 15</div>,
-  ],
   navigationStep: 5,
   slideTransition: {
     speed: 400,
@@ -80,18 +71,6 @@ export const mockInitialNonInfiniteSliderState = {
     '8': -80,
     '9': -90,
   },
-  slides: [
-    <div key={1}>I am a slide. My index is 1</div>,
-    <div key={2}>I am a slide. My index is 2</div>,
-    <div key={3}>I am a slide. My index is 3</div>,
-    <div key={4}>I am a slide. My index is 4</div>,
-    <div key={5}>I am a slide. My index is 5</div>,
-    <div key={6}>I am a slide. My index is 6</div>,
-    <div key={7}>I am a slide. My index is 7</div>,
-    <div key={8}>I am a slide. My index is 8</div>,
-    <div key={9}>I am a slide. My index is 9</div>,
-    <div key={10}>I am a slide. My index is 10</div>,
-  ],
   navigationStep: 5,
   slideTransition: {
     speed: 400,

--- a/react/__tests__/SliderTrack.test.tsx
+++ b/react/__tests__/SliderTrack.test.tsx
@@ -4,6 +4,7 @@ import { render, fireEvent } from '@vtex/test-tools/react'
 import SliderTrack from '../components/SliderTrack'
 import { useSliderState } from '../components/SliderContext'
 import {
+  mockInitialSlides,
   mockInitialInfiniteSliderState,
   mockInitialNonInfiniteSliderState,
 } from '../__fixtures__/SliderStateContext'
@@ -31,7 +32,9 @@ describe('Basic rendering', () => {
         usePagination
         totalItems={TOTAL_ITEMS}
         infinite
-      />
+      >
+        {mockInitialSlides}
+      </SliderTrack>
     )
 
     let renderedSliderTrack = getByTestId('slider-track')
@@ -44,12 +47,9 @@ describe('Basic rendering', () => {
 
     // slidesPerPage === totalItems
     rerender(
-      <SliderTrack
-        centerMode="disabled"
-        usePagination
-        totalItems={5}
-        infinite
-      />
+      <SliderTrack centerMode="disabled" usePagination totalItems={5} infinite>
+        {mockInitialSlides}
+      </SliderTrack>
     )
     renderedSliderTrack = getByTestId('slider-track')
     expect(renderedSliderTrack.style.width).toEqual(
@@ -58,12 +58,9 @@ describe('Basic rendering', () => {
 
     // slidesPerPage > totalItems
     rerender(
-      <SliderTrack
-        centerMode="disabled"
-        usePagination
-        totalItems={3}
-        infinite
-      />
+      <SliderTrack centerMode="disabled" usePagination totalItems={3} infinite>
+        {mockInitialSlides}
+      </SliderTrack>
     )
     renderedSliderTrack = getByTestId('slider-track')
     expect(renderedSliderTrack.style.width).toEqual('100%')
@@ -72,12 +69,9 @@ describe('Basic rendering', () => {
   it('should render with correct translate3d(x, y, z), set to the initial slide', () => {
     // infinite slider
     const { getByTestId, rerender } = render(
-      <SliderTrack
-        centerMode="disabled"
-        usePagination
-        totalItems={10}
-        infinite
-      />
+      <SliderTrack centerMode="disabled" usePagination totalItems={10} infinite>
+        {mockInitialSlides}
+      </SliderTrack>
     )
 
     let renderedSliderTrack = getByTestId('slider-track')
@@ -97,7 +91,9 @@ describe('Basic rendering', () => {
         usePagination
         totalItems={10}
         infinite={false}
-      />
+      >
+        {mockInitialSlides}
+      </SliderTrack>
     )
 
     renderedSliderTrack = getByTestId('slider-track')
@@ -115,7 +111,9 @@ describe('Basic rendering', () => {
         usePagination
         totalItems={TOTAL_ITEMS}
         infinite
-      />
+      >
+        {mockInitialSlides}
+      </SliderTrack>
     )
 
     let renderedSliderTrack = getByTestId('slider-track')
@@ -147,7 +145,9 @@ describe('Basic rendering', () => {
         usePagination
         totalItems={TOTAL_ITEMS}
         infinite={false}
-      />
+      >
+        {mockInitialSlides}
+      </SliderTrack>
     )
 
     renderedSliderTrack = getByTestId('slider-track')
@@ -169,7 +169,9 @@ describe('Basic rendering', () => {
         usePagination
         totalItems={TOTAL_ITEMS}
         infinite
-      />
+      >
+        {mockInitialSlides}
+      </SliderTrack>
     )
 
     let renderedSlides = INDEXES.map(idx =>
@@ -189,7 +191,9 @@ describe('Basic rendering', () => {
         usePagination
         totalItems={TOTAL_ITEMS}
         infinite={false}
-      />
+      >
+        {mockInitialSlides}
+      </SliderTrack>
     )
 
     renderedSlides = INDEXES.map(idx =>
@@ -204,18 +208,20 @@ describe('Basic rendering', () => {
     const INDEXES = Array.from(new Array(10), (_, i) => i + 1)
 
     // infinite slider
-    const { rerender, queryByText } = render(
+    const { rerender, queryByText, queryAllByText } = render(
       <SliderTrack
         centerMode="disabled"
         usePagination={false}
         totalItems={TOTAL_ITEMS}
         infinite
-      />
+      >
+        {mockInitialSlides}
+      </SliderTrack>
     )
 
-    let renderedSlides = INDEXES.map(idx =>
-      queryByText(`I am a slide. My index is ${idx}`)
-    ).filter(Boolean)
+    let renderedSlides: Array<HTMLElement | null | void> = INDEXES.map(idx =>
+      expect(queryAllByText(`I am a slide. My index is ${idx}`)).toHaveLength(2)
+    )
 
     expect(renderedSlides).toHaveLength(TOTAL_ITEMS)
 
@@ -230,7 +236,9 @@ describe('Basic rendering', () => {
         usePagination={false}
         totalItems={TOTAL_ITEMS}
         infinite={false}
-      />
+      >
+        {mockInitialSlides}
+      </SliderTrack>
     )
 
     renderedSlides = INDEXES.map(idx =>
@@ -258,7 +266,9 @@ describe('Behavior upon interaction', () => {
         totalItems={TOTAL_ITEMS}
         infinite
         usePagination
-      />
+      >
+        {mockInitialSlides}
+      </SliderTrack>
     )
 
     let renderedTrack = getByTestId('slider-track')
@@ -287,7 +297,9 @@ describe('Behavior upon interaction', () => {
         totalItems={TOTAL_ITEMS}
         infinite
         usePagination
-      />
+      >
+        {mockInitialSlides}
+      </SliderTrack>
     )
 
     renderedTrack = getByTestId('slider-track')
@@ -322,7 +334,9 @@ describe('Accessibility', () => {
         usePagination
         totalItems={TOTAL_ITEMS}
         infinite
-      />
+      >
+        {mockInitialSlides}
+      </SliderTrack>
     )
 
     const renderedSliderTrack = getByTestId('slider-track')

--- a/react/components/Slider.tsx
+++ b/react/components/Slider.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useRef, Fragment } from 'react'
+import React, { FC, useRef, Fragment, ReactNode } from 'react'
 import { useDevice } from 'vtex.device-detector'
 import { useCssHandles } from 'vtex.css-handles'
 
@@ -14,6 +14,9 @@ interface Props extends SliderLayoutSiteEditorProps {
   totalItems: number
   itemsPerPage: number
   centerMode: SliderLayoutProps['centerMode']
+  // This type comes from React itself. It is the return type for
+  // React.Children.toArray().
+  children?: Array<Exclude<ReactNode, boolean | null | undefined>>
 }
 
 const CSS_HANDLES = ['sliderLayoutContainer', 'sliderTrackContainer'] as const

--- a/react/components/SliderContext.tsx
+++ b/react/components/SliderContext.tsx
@@ -222,7 +222,7 @@ const SliderContextProvider: FC<SliderContextProps> = ({
   const transformMap = useMemo(() => {
     const currentMap: Record<number, number> = {}
 
-    Array.from(Array(newTotalItems).keys()).forEach(idx => {
+    for (let idx = 0; idx < newTotalItems; ++idx) {
       const currIdx = infinite ? idx - resolvedSlidesPerPage : idx
       let transformValue = -(slideWidth * idx)
 
@@ -249,7 +249,7 @@ const SliderContextProvider: FC<SliderContextProps> = ({
       }
 
       currentMap[currIdx] = transformValue
-    })
+    }
 
     return currentMap
   }, [slideWidth, newTotalItems, resolvedSlidesPerPage, infinite, centerMode])

--- a/react/components/SliderContext.tsx
+++ b/react/components/SliderContext.tsx
@@ -3,7 +3,6 @@ import React, {
   useReducer,
   useContext,
   FC,
-  ReactNode,
   useMemo,
   useState,
 } from 'react'
@@ -60,7 +59,6 @@ interface AdjustContextValuesAction {
   payload: {
     transformMap: State['transformMap']
     slideWidth: State['slideWidth']
-    newSlides: State['slides']
     slidesPerPage: State['slidesPerPage']
     transform: State['transform']
     navigationStep: State['navigationStep']
@@ -87,16 +85,12 @@ interface State extends Partial<SliderLayoutProps> {
   isOnTouchMove: boolean
   useSlidingTransitionEffect: boolean
   transformMap: Record<number, number>
-  slides: Array<Exclude<ReactNode, boolean | null | undefined>>
   slideTransition: Exclude<SliderLayoutProps['slideTransition'], undefined>
 }
 
 interface SliderContextProps extends SliderLayoutProps {
   totalItems: number
   infinite: SliderLayoutSiteEditorProps['infinite']
-  // This type comes from React itself. It is the return type for
-  // React.Children.toArray().
-  slides: Array<Exclude<ReactNode, boolean | null | undefined>>
 }
 
 type Action =
@@ -165,7 +159,6 @@ function sliderContextReducer(state: State, action: Action): State {
         ...state,
         transformMap: action.payload.transformMap,
         slideWidth: action.payload.slideWidth,
-        slides: action.payload.newSlides,
         slidesPerPage: action.payload.slidesPerPage,
         transform: action.payload.transform,
         navigationStep: action.payload.navigationStep,
@@ -183,7 +176,6 @@ const SliderContextProvider: FC<SliderContextProps> = ({
   totalItems,
   label = 'slider',
   navigationStep = 'page',
-  slides,
   infinite = false,
   itemsPerPage,
   centerMode,
@@ -210,18 +202,12 @@ const SliderContextProvider: FC<SliderContextProps> = ({
   const resolvedSlidesPerPage: number =
     totalItems <= itemsPerPage ? totalItems : itemsPerPage
 
-  const postRenderedSlides = infinite
-    ? slides.slice(0, resolvedSlidesPerPage)
-    : []
+  const hiddenSlides = infinite ? resolvedSlidesPerPage * 2 : 0
 
-  const preRenderedSlides = infinite
-    ? slides.slice(slides.length - resolvedSlidesPerPage)
-    : []
-
-  const newSlides = preRenderedSlides.concat(slides, postRenderedSlides)
+  const newTotalItems = hiddenSlides + totalItems
 
   const slideWidth = useMemo(() => {
-    const baseSlideWidth = 100 / newSlides.length
+    const baseSlideWidth = 100 / newTotalItems
 
     let resultingSlideWidth = baseSlideWidth
 
@@ -231,12 +217,12 @@ const SliderContextProvider: FC<SliderContextProps> = ({
     }
 
     return resultingSlideWidth
-  }, [newSlides.length, centerMode, resolvedSlidesPerPage])
+  }, [newTotalItems, centerMode, resolvedSlidesPerPage])
 
   const transformMap = useMemo(() => {
     const currentMap: Record<number, number> = {}
 
-    newSlides.forEach((_, idx) => {
+    Array.from(Array(newTotalItems).keys()).forEach(idx => {
       const currIdx = infinite ? idx - resolvedSlidesPerPage : idx
       let transformValue = -(slideWidth * idx)
 
@@ -266,7 +252,7 @@ const SliderContextProvider: FC<SliderContextProps> = ({
     })
 
     return currentMap
-  }, [slideWidth, newSlides, resolvedSlidesPerPage, infinite, centerMode])
+  }, [slideWidth, newTotalItems, resolvedSlidesPerPage, infinite, centerMode])
 
   const initialSlide = useMemo(() => sliderGroupState?.currentSlide ?? 0, [
     sliderGroupState,
@@ -283,7 +269,6 @@ const SliderContextProvider: FC<SliderContextProps> = ({
     currentSlide: initialSlide,
     transform: initialTransform,
     transformMap,
-    slides: newSlides,
     navigationStep: resolvedNavigationStep,
     slideTransition,
     itemsPerPage,
@@ -303,7 +288,6 @@ const SliderContextProvider: FC<SliderContextProps> = ({
       type: 'ADJUST_CONTEXT_VALUES',
       payload: {
         transformMap,
-        newSlides,
         slideWidth,
         slidesPerPage: resolvedSlidesPerPage,
         transform: transformMap[state.currentSlide],

--- a/react/components/SliderTrack.tsx
+++ b/react/components/SliderTrack.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+import React, { FC, ReactNode } from 'react'
 import { useCssHandles, applyModifiers } from 'vtex.css-handles'
 
 import { useSliderState, useSliderDispatch } from './SliderContext'
@@ -12,6 +12,9 @@ interface Props {
   infinite: boolean
   usePagination: boolean
   centerMode: SliderLayoutProps['centerMode']
+  // This type comes from React itself. It is the return type for
+  // React.Children.toArray().
+  children?: Array<Exclude<ReactNode, boolean | null | undefined>>
 }
 
 const resolveAriaAttributes = (
@@ -49,10 +52,10 @@ const getFirstOrLastVisible = (slidesPerPage: number, index: number) => {
 }
 
 const SliderTrack: FC<Props> = ({
-  totalItems,
   infinite,
   usePagination,
   centerMode,
+  children,
 }) => {
   const {
     slideWidth,
@@ -61,9 +64,9 @@ const SliderTrack: FC<Props> = ({
     isOnTouchMove,
     useSlidingTransitionEffect,
     slideTransition: { speed, timing, delay },
-    slides,
     transformMap,
     transform,
+    totalItems,
   } = useSliderState()
 
   const dispatch = useSliderDispatch()
@@ -76,6 +79,14 @@ const SliderTrack: FC<Props> = ({
     totalItems,
     centerMode,
   })
+
+  const postRenderedSlides =
+    infinite && children ? children.slice(0, slidesPerPage) : []
+
+  const preRenderedSlides =
+    infinite && children ? children.slice(children.length - slidesPerPage) : []
+
+  const slides = preRenderedSlides.concat(children ?? [], postRenderedSlides)
 
   const trackWidth =
     slidesPerPage <= totalItems

--- a/react/components/SliderTrack.tsx
+++ b/react/components/SliderTrack.tsx
@@ -55,6 +55,7 @@ const SliderTrack: FC<Props> = ({
   infinite,
   usePagination,
   centerMode,
+  totalItems,
   children,
 }) => {
   const {
@@ -66,7 +67,6 @@ const SliderTrack: FC<Props> = ({
     slideTransition: { speed, timing, delay },
     transformMap,
     transform,
-    totalItems,
   } = useSliderState()
 
   const dispatch = useSliderDispatch()


### PR DESCRIPTION
#### What problem is this solving?

Slides were only re-rendered when the user navigated through the pages or the number of slides changed. That caused slides to not re-render even if their props were updated. React usually re-renders the children if they had their props changed, but the new slides were not being dispatched by the Context, so it was not passed down the tree. 

This PR fixes the problem by removing the slides from the Context and passing them through the tree as regular children. By handling them this way, there's no need to implement custom code to tell if the slides have changed.

#### How to test it?

Go to the search page of this [workspace](https://fixskuselector--eriksbikeshop.myvtex.com/cycling/bicycles/style_Electricbike) and find a bike with a Sku Selector with more than 3 options. As you change your size selection, it all should work just fine.

[Carrefour workspace](https://icaro--carrefourbr.myvtex.com/)
[Storecomponents workspace](https://icaro--storecomponents.myvtex.com/)

#### Screenshots or example usage:

[This](https://user-images.githubusercontent.com/8127610/93810784-84c95d00-fc25-11ea-9294-c5e3a63b77cd.gif) was the behavior before the fix.

And [this](https://user-images.githubusercontent.com/8127610/93811549-aecf4f00-fc26-11ea-8cf7-53799bb7695d.gif) is the current behavior, after the fix.


#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/Is1O1TWV0LEJi/source.gif)
