### PR TITLE
Stop event bubbling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Fixed
-- Be able to click the navigation buttons when they're placed inside a link (prevent event bubbling)
+- Navigation controls would not work when the `slider` was placed inside an `<a>` tag. This is the case if you were to place a `slider-layout` inside of a `product-summary`.
 
 ## [0.15.1] - 2020-09-24
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Be able to click the navigation buttons when they're placed inside a link (prevent event bubbling)
 
 ## [0.15.1] - 2020-09-24
 ### Fixed

--- a/react/components/Arrow.tsx
+++ b/react/components/Arrow.tsx
@@ -43,8 +43,8 @@ const Arrow: FC<Props> = ({
     event: React.MouseEvent<HTMLButtonElement, MouseEvent>
   ) {
     if (event) {
-      event.stopPropagation();
-      event.preventDefault();
+      event.stopPropagation()
+      event.preventDefault()
     }
 
     if (orientation === 'left') {

--- a/react/components/Arrow.tsx
+++ b/react/components/Arrow.tsx
@@ -40,8 +40,13 @@ const Arrow: FC<Props> = ({
   useKeyboardArrows(goBack, goForward)
 
   function handleArrowClick(
-    _: React.MouseEvent<HTMLButtonElement, MouseEvent>
+    event: React.MouseEvent<HTMLButtonElement, MouseEvent>
   ) {
+    if (event) {
+      event.stopPropagation();
+      event.preventDefault();
+    }
+
     if (orientation === 'left') {
       goBack()
     }

--- a/react/components/PaginationDots.tsx
+++ b/react/components/PaginationDots.tsx
@@ -53,9 +53,14 @@ const PaginationDots: FC<Props> = ({ controls, totalItems, infinite }) => {
     totalItems
   )
 
-  const handleDotClick = (index: number) => {
+  const handleDotClick = (event: React.KeyboardEvent | React.MouseEvent, index: number) => {
     // Considering that each pagination dot represents a page, pageDelta
     // represents how many pages did the user "skip" by clicking in the dot.
+    if (event) {
+      event.stopPropagation();
+      event.preventDefault();
+    }
+
     const pageDelta =
       index - getSelectedDot(passVisibleSlides, currentSlide, slidesPerPage)
 
@@ -89,8 +94,8 @@ const PaginationDots: FC<Props> = ({ controls, totalItems, infinite }) => {
             }}
             key={index}
             tabIndex={index}
-            onKeyDown={() => handleDotClick(index)}
-            onClick={() => handleDotClick(index)}
+            onKeyDown={(event) => handleDotClick(event, index)}
+            onClick={(event) => handleDotClick(event, index)}
             role="button"
             aria-controls={controls}
             aria-label={`Dot ${index + 1} of ${slideIndexes.length}`}

--- a/react/components/PaginationDots.tsx
+++ b/react/components/PaginationDots.tsx
@@ -53,12 +53,15 @@ const PaginationDots: FC<Props> = ({ controls, totalItems, infinite }) => {
     totalItems
   )
 
-  const handleDotClick = (event: React.KeyboardEvent | React.MouseEvent, index: number) => {
+  const handleDotClick = (
+    event: React.KeyboardEvent | React.MouseEvent,
+    index: number
+  ) => {
     // Considering that each pagination dot represents a page, pageDelta
     // represents how many pages did the user "skip" by clicking in the dot.
     if (event) {
-      event.stopPropagation();
-      event.preventDefault();
+      event.stopPropagation()
+      event.preventDefault()
     }
 
     const pageDelta =
@@ -94,8 +97,8 @@ const PaginationDots: FC<Props> = ({ controls, totalItems, infinite }) => {
             }}
             key={index}
             tabIndex={index}
-            onKeyDown={(event) => handleDotClick(event, index)}
-            onClick={(event) => handleDotClick(event, index)}
+            onKeyDown={event => handleDotClick(event, index)}
+            onClick={event => handleDotClick(event, index)}
             role="button"
             aria-controls={controls}
             aria-label={`Dot ${index + 1} of ${slideIndexes.length}`}

--- a/react/components/PaginationDots.tsx
+++ b/react/components/PaginationDots.tsx
@@ -57,13 +57,13 @@ const PaginationDots: FC<Props> = ({ controls, totalItems, infinite }) => {
     event: React.KeyboardEvent | React.MouseEvent,
     index: number
   ) => {
-    // Considering that each pagination dot represents a page, pageDelta
-    // represents how many pages did the user "skip" by clicking in the dot.
     if (event) {
       event.stopPropagation()
       event.preventDefault()
     }
 
+    // Considering that each pagination dot represents a page, pageDelta
+    // represents how many pages did the user "skip" by clicking in the dot.
     const pageDelta =
       index - getSelectedDot(passVisibleSlides, currentSlide, slidesPerPage)
 


### PR DESCRIPTION
#### What problem is this solving?
If you add a slider-layout over an `a` tag, you cannot use the navigation buttons.
<!--- What is the motivation and context for this change? -->

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->
![image](https://user-images.githubusercontent.com/284515/97309505-dd9d9e00-1840-11eb-809b-5a495d127ef2.png)

[Workspace](https://doru--fstudio.myvtex.com/product%20testing?_q=product%20testing&fuzzy=0&map=ft&operator=and&priceRange=249%20TO%2019399)

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](https://giphy.com/gifs/reaction-26CaLKiimsm3ibpE4)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/26CaLKiimsm3ibpE4/giphy.gif)
