### PR TITLE
Fix/left arrow disabled conditional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Left arrow becoming disabled before reaching the first page when props `infinite` is false, `itemsPerPage` is greater than one and the number of items is odd. 
 
 ## [0.15.1] - 2020-09-24
 ### Fixed

--- a/react/components/Arrow.tsx
+++ b/react/components/Arrow.tsx
@@ -25,12 +25,12 @@ const Arrow: FC<Props> = ({
   infinite,
   arrowSize,
 }) => {
-  const { currentSlide, slidesPerPage, navigationStep } = useSliderState()
+  const { currentSlide, slidesPerPage } = useSliderState()
   const { goBack, goForward } = useSliderControls(infinite)
 
   const handles = useCssHandles(CSS_HANDLES)
 
-  const isLeftEndReach = !(currentSlide - (navigationStep || 1) >= 0)
+  const isLeftEndReach = !(currentSlide - 1 >= 0)
   const isRightEndReach = !(currentSlide + 1 + slidesPerPage <= totalItems)
   const disabled =
     !infinite &&


### PR DESCRIPTION
#### What problem is this solving?

The left arrow becomes disabled before reaching the first page, making it only possible to reach it through the dots or dragging the slider. This scenario only happens when the slider is **not infinite**, with **more than two items per page**, and **the total number of items in the slider is an odd number**.

#### How to test it?

Click on the right arrows until the last page, after that return through the left arrows, in the current slider the left arrow will be disabled before reaching the first page.

[Current Slider](https://sliderbug--tokstokio.myvtex.com/)

[Fixed Slider](https://sliderfixed--tokstokio.myvtex.com/)

#### Screenshots or example usage:

Before:
![image](https://user-images.githubusercontent.com/55160541/96182210-8972ef80-0f0b-11eb-84cd-47c8aa6c468d.png)

After:
![image](https://user-images.githubusercontent.com/55160541/96182264-a0194680-0f0b-11eb-9a6e-86c14d896bc4.png)


#### How does this PR make you feel? 

![](https://media.giphy.com/media/xT5LMHxhOfscxPfIfm/source.gif)
