### PR TITLE
Pass __isDuplicated property to each duplicated child

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `SliderTrack`: prevent duplicate images with `analyticsProperties`
 
 ## [0.19.2] - 2021-07-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Fixed
-- `SliderTrack`: prevent duplicate images with `analyticsProperties: provide` on infinite mode.
+### Added
+- `SliderTrack`: Pass `__isDuplicated` prop to duplicated child.
 
 ## [0.19.2] - 2021-07-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Fixed
-- `SliderTrack`: prevent duplicate images with `analyticsProperties`
+- `SliderTrack`: prevent duplicate images with `analyticsProperties: provide` on infinite mode.
 
 ## [0.19.2] - 2021-07-15
 

--- a/react/components/SliderTrack.tsx
+++ b/react/components/SliderTrack.tsx
@@ -1,4 +1,4 @@
-import React, { FC, ReactNode } from 'react'
+import React, { cloneElement, FC, ReactElement, ReactNode } from 'react'
 
 import {
   useSliderState,
@@ -59,6 +59,22 @@ const getFirstOrLastVisible = (slidesPerPage: number, index: number) => {
   return ''
 }
 
+const removeAnalyticsProperties = (children: ReactElement[]) => {
+  return React.Children.toArray(
+    React.Children.map(children, child =>
+      typeof child === 'string' || typeof child === 'number'
+        ? child
+        : cloneElement<{ analyticsProperties?: string }>(child, {
+            ...child.props,
+            // This prevent to trigger twice the promoView events
+            ...(child.props?.analyticsProperties
+              ? { analyticsProperties: 'none' }
+              : {}),
+          })
+    )
+  )
+}
+
 const SliderTrack: FC<Props> = ({
   infinite,
   usePagination,
@@ -89,10 +105,19 @@ const SliderTrack: FC<Props> = ({
   })
 
   const postRenderedSlides =
-    infinite && children ? children.slice(0, slidesPerPage) : []
+    infinite && children
+      ? removeAnalyticsProperties(children as ReactElement[]).slice(
+          0,
+          slidesPerPage
+        )
+      : []
 
   const preRenderedSlides =
-    infinite && children ? children.slice(children.length - slidesPerPage) : []
+    infinite && children
+      ? removeAnalyticsProperties(children as ReactElement[]).slice(
+          children.length - slidesPerPage
+        )
+      : []
 
   const slides = preRenderedSlides.concat(children ?? [], postRenderedSlides)
 

--- a/react/components/SliderTrack.tsx
+++ b/react/components/SliderTrack.tsx
@@ -64,12 +64,10 @@ const removeAnalyticsProperties = (children: ReactElement[]) => {
     React.Children.map(children, child =>
       typeof child === 'string' || typeof child === 'number'
         ? child
-        : cloneElement<{ analyticsProperties?: string }>(child, {
+        : cloneElement(child, {
             ...child.props,
-            // This prevent to trigger twice the promoView events
-            ...(child.props?.analyticsProperties
-              ? { analyticsProperties: 'none' }
-              : {}),
+            // Tells the component it is being duplicated. Each component should handle it
+            __isDuplicated: true,
           })
     )
   )


### PR DESCRIPTION
#### What problem is this solving?
When slider with infinite mode true and has duplicated children, each duplicated child will receive `__isDuplicated` property

#### How to test it?
1. Go to the [Workspace](https://brasileiro--storecomponents.myvtex.com/)
2. Click on the carousel arrows until you get the first image again
3. Check if the promoView event is not triggered twice for the first image.

#### Screenshots or example usage:

#### Describe alternatives you've considered, if any.

#### Related to / Depends on
https://github.com/vtex-apps/store-image/pull/52

#### How does this PR make you feel? [:link:](http://giphy.com/)
![](https://media.giphy.com/media/lKXEBR8m1jWso/giphy.gif?cid=ecf05e47yt3doxoyv5juvpupha4y9fmpmjc3f5waunpmcawy&rid=giphy.gif&ct=g)
