### PR TITLE
added `useKeyboardArrow` prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `useKeyboardArrow` prop
+
 ## [0.22.1] - 2021-12-17
 
 ### Fixed

--- a/docs/README.md
+++ b/docs/README.md
@@ -78,6 +78,7 @@ Now, you are able to use all blocks exported by the `slider-layout` app. Check o
 | `arrowSize`            | `number` / `object`   | Slider arrows size (height and width) in pixels. This is a responsive prop, which means you can pass to it an object with different values for each breakpoint (`desktop`, `mobile`, `tablet`, and `phone`).  | `25`  |
 | `centerMode`            | `enum` / `object`   | Defines the slider elements positioning on the screen. Possible values are: `center` (elements are centered, allowing users to see a peek of the previous and next slides), `to-the-left` (align elements to the left side, allowing users to see a peek of the next slide, but not the previous one), and `disabled` (disables the feature, rendering elements on the whole screen without taking a peek in the previous and next slides). Notice: This is a responsive prop, which means you can pass to it an object with different values for each breakpoint (`desktop`, `mobile`, `tablet`, and `phone`).  | `disabled`  |
 | `centerModeSlidesGap`   | `number` | Number of pixels between slides when `centerMode` is set to `center` or `to-the-left`. | `undefined`  |
+| `useKeyboardArrow` | `boolean` |  Defines if the slides should move when pressing the keyboard arrow | `true` |
 
 - **`itemsPerPage` object**
 

--- a/react/SliderLayout.tsx
+++ b/react/SliderLayout.tsx
@@ -25,6 +25,7 @@ function SliderLayout({
   showNavigationArrows = 'always',
   showPaginationDots = 'always',
   usePagination = true,
+  useKeyboardArrow = true,
   fullWidth = true,
   arrowSize = 25,
   children,
@@ -62,6 +63,7 @@ function SliderLayout({
           centerMode={responsiveCenterMode}
           centerModeSlidesGap={centerModeSlidesGap}
           infinite={infinite}
+          useKeyboardArrow={useKeyboardArrow}
           showNavigationArrows={showNavigationArrows}
           showPaginationDots={showPaginationDots}
           totalItems={totalSlides}

--- a/react/__tests__/Arrows.test.tsx
+++ b/react/__tests__/Arrows.test.tsx
@@ -60,6 +60,7 @@ describe('Accessibility', () => {
           totalItems={20}
           orientation="left"
           controls="slider-items"
+          useKeyboardArrow
         />
         <Arrow
           infinite
@@ -67,6 +68,7 @@ describe('Accessibility', () => {
           totalItems={20}
           orientation="right"
           controls="slider-items"
+          useKeyboardArrow
         />
       </Fragment>
     )
@@ -92,6 +94,7 @@ describe('Behavior upon interaction', () => {
         totalItems={20}
         orientation="right"
         controls="slider-items"
+        useKeyboardArrow
       />
     )
 
@@ -109,6 +112,7 @@ describe('Behavior upon interaction', () => {
         totalItems={20}
         orientation="left"
         controls="slider-items"
+        useKeyboardArrow
       />
     )
 
@@ -126,6 +130,7 @@ describe('Behavior upon interaction', () => {
         totalItems={10}
         orientation="left"
         controls="slider-items"
+        useKeyboardArrow
       />
     )
 
@@ -149,6 +154,7 @@ describe('Behavior upon interaction', () => {
         totalItems={10}
         orientation="right"
         controls="slider-items"
+        useKeyboardArrow
       />
     )
 

--- a/react/__tests__/Slider.test.tsx
+++ b/react/__tests__/Slider.test.tsx
@@ -50,6 +50,7 @@ describe('Basic rendering', () => {
         fullWidth
         infinite
         usePagination
+        useKeyboardArrow
       />
     )
 
@@ -76,6 +77,7 @@ describe('Basic rendering', () => {
         arrowSize={25}
         fullWidth
         infinite
+        useKeyboardArrow
       />
     )
 
@@ -104,6 +106,7 @@ describe('Basic rendering', () => {
         usePagination
         fullWidth
         infinite
+        useKeyboardArrow
       />
     )
 
@@ -134,6 +137,7 @@ describe('Basic rendering', () => {
         arrowSize={25}
         usePagination
         infinite
+        useKeyboardArrow
       />
     )
 
@@ -162,6 +166,7 @@ describe('Behavior upon interaction', () => {
         usePagination
         fullWidth
         infinite
+        useKeyboardArrow
       />
     )
 
@@ -185,6 +190,7 @@ describe('Behavior upon interaction', () => {
         usePagination
         fullWidth
         infinite
+        useKeyboardArrow
       />
     )
 
@@ -208,6 +214,7 @@ describe('Behavior upon interaction', () => {
         usePagination
         fullWidth
         infinite
+        useKeyboardArrow
       />
     )
 
@@ -231,6 +238,7 @@ describe('Behavior upon interaction', () => {
         usePagination
         fullWidth
         infinite
+        useKeyboardArrow
       />
     )
 
@@ -258,6 +266,7 @@ describe('Behavior upon interaction', () => {
         usePagination
         fullWidth
         infinite
+        useKeyboardArrow
       />
     )
 
@@ -281,6 +290,7 @@ describe('Behavior upon interaction', () => {
         usePagination
         fullWidth
         infinite
+        useKeyboardArrow
       />
     )
 
@@ -304,6 +314,7 @@ describe('Behavior upon interaction', () => {
         usePagination
         fullWidth
         infinite
+        useKeyboardArrow
       />
     )
 
@@ -327,6 +338,7 @@ describe('Behavior upon interaction', () => {
         usePagination
         fullWidth
         infinite
+        useKeyboardArrow
       />
     )
 

--- a/react/components/Arrow.tsx
+++ b/react/components/Arrow.tsx
@@ -13,6 +13,7 @@ interface Props {
   totalItems: number
   infinite: boolean
   arrowSize: number
+  useKeyboardArrow: boolean
 }
 
 export const CSS_HANDLES = [
@@ -28,6 +29,7 @@ const Arrow: FC<Props> = ({
   totalItems,
   infinite,
   arrowSize,
+  useKeyboardArrow
 }) => {
   const { currentSlide, slidesPerPage } = useSliderState()
   const { goBack, goForward } = useSliderControls(infinite)
@@ -41,7 +43,7 @@ const Arrow: FC<Props> = ({
     ((orientation === 'left' && isLeftEndReached) ||
       (orientation === 'right' && isRightEndReached))
 
-  useKeyboardArrows(goBack, goForward)
+  useKeyboardArrow && useKeyboardArrows(goBack, goForward)
 
   function handleArrowClick(
     event: React.MouseEvent<HTMLButtonElement, MouseEvent>

--- a/react/components/Slider.tsx
+++ b/react/components/Slider.tsx
@@ -24,6 +24,7 @@ interface Props extends SliderLayoutSiteEditorProps {
   itemsPerPage: number
   centerMode: SliderLayoutProps['centerMode']
   centerModeSlidesGap?: SliderLayoutProps['centerModeSlidesGap']
+  useKeyboardArrow: boolean
   // This type comes from React itself. It is the return type for
   // React.Children.toArray().
   children?: Array<Exclude<ReactNode, boolean | null | undefined>>
@@ -49,6 +50,7 @@ const Slider: FC<Props> = ({
   itemsPerPage,
   centerMode,
   centerModeSlidesGap,
+  useKeyboardArrow
 }) => {
   const { handles } = useContextCssHandles()
   const { isMobile } = useDevice()
@@ -129,6 +131,7 @@ const Slider: FC<Props> = ({
             controls={controls}
             infinite={infinite}
             arrowSize={arrowSize}
+            useKeyboardArrow={useKeyboardArrow}
           />
           <Arrow
             totalItems={totalItems}
@@ -136,6 +139,7 @@ const Slider: FC<Props> = ({
             controls={controls}
             infinite={infinite}
             arrowSize={arrowSize}
+            useKeyboardArrow={useKeyboardArrow}
           />
         </Fragment>
       )}

--- a/react/components/SliderContext.tsx
+++ b/react/components/SliderContext.tsx
@@ -97,6 +97,7 @@ export interface SliderLayoutProps {
     'center' | 'to-the-left' | 'disabled'
   >
   centerModeSlidesGap?: number
+  useKeyboardArrow?: boolean
 }
 
 interface State extends Partial<SliderLayoutProps> {


### PR DESCRIPTION
#### What problem is this solving?

Now we can configure if we want to move the sliders using the keyboard arrows

#### How to test it?

Open WS and try to move the sliders with the arrow keys
*Note: 2 sliders have the prop with the default value, which should move, but the others do not

[Workspace](https://proparrow--gigadigital.myvtex.com/)

#### Screenshots or example usage:

[Loom Video](https://www.loom.com/share/da8d082001ec4361b3911363fcfd22e4)

#### How does this PR make you feel? [:link:](http://giphy.com/)

![](https://media.giphy.com/media/QmeB1Hr5fz7a0/giphy.gif)
