### PR TITLE
fix: Infinite behavior when navigationStep is defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Infinite behavior when `navigationStep` is defined.
+
 ## [0.22.1] - 2021-12-17
 
 ### Fixed

--- a/react/__fixtures__/SliderStateContext.tsx
+++ b/react/__fixtures__/SliderStateContext.tsx
@@ -71,7 +71,7 @@ export const mockInitialNonInfiniteSliderState = {
     '8': -80,
     '9': -90,
   },
-  navigationStep: 5,
+  navigationStep: 2,
   slideTransition: {
     speed: 400,
     delay: 0,

--- a/react/__fixtures__/SliderStateContext.tsx
+++ b/react/__fixtures__/SliderStateContext.tsx
@@ -40,7 +40,7 @@ export const mockInitialInfiniteSliderState = {
     '-2': -15,
     '-1': -20,
   },
-  navigationStep: 5,
+  navigationStep: 2,
   slideTransition: {
     speed: 400,
     delay: 0,

--- a/react/__tests__/SliderTrack.test.tsx
+++ b/react/__tests__/SliderTrack.test.tsx
@@ -323,8 +323,8 @@ describe('Behavior upon interaction', () => {
     expect(mockDispatch).toHaveBeenCalledWith({
       type: 'ADJUST_CURRENT_SLIDE',
       payload: {
-        currentSlide: 5,
-        transform: mockInitialInfiniteSliderState.transformMap[5],
+        currentSlide: 8,
+        transform: mockInitialInfiniteSliderState.transformMap[8],
       },
     })
   })

--- a/react/__tests__/SliderTrack.test.tsx
+++ b/react/__tests__/SliderTrack.test.tsx
@@ -323,8 +323,8 @@ describe('Behavior upon interaction', () => {
     expect(mockDispatch).toHaveBeenCalledWith({
       type: 'ADJUST_CURRENT_SLIDE',
       payload: {
-        currentSlide: 8,
-        transform: mockInitialInfiniteSliderState.transformMap[8],
+        currentSlide: 9,
+        transform: mockInitialInfiniteSliderState.transformMap[9],
       },
     })
   })

--- a/react/__tests__/hooks.test.tsx
+++ b/react/__tests__/hooks.test.tsx
@@ -1,15 +1,18 @@
 import { hooks } from '@vtex/test-tools/react'
 
-import { useSliderState } from '../components/SliderContext'
 import { useSliderControls } from '../hooks/useSliderControls'
-import { mockInitialInfiniteSliderState } from '../__fixtures__/SliderStateContext'
+import {
+  mockInitialInfiniteSliderState,
+  mockInitialNonInfiniteSliderState,
+} from '../__fixtures__/SliderStateContext'
 
 const { renderHook, act } = hooks
 
 const mockDispatch = jest.fn()
+let mockSliderInitialState: any
 
 jest.mock('../components/SliderContext', () => ({
-  useSliderState: () => mockInitialInfiniteSliderState,
+  useSliderState: () => mockSliderInitialState,
   useSliderDispatch: () => mockDispatch,
 }))
 
@@ -56,6 +59,7 @@ describe('useScreenResize', () => {
 describe('useSliderControls', () => {
   describe('goBack()', () => {
     it('should dispatch a SLIDE action to go back the navigationStep when goBack() is called with no arguments', async () => {
+      mockSliderInitialState = mockInitialInfiniteSliderState
       const { result } = renderHook(() => useSliderControls(true))
 
       await act(() => Promise.resolve())
@@ -71,6 +75,7 @@ describe('useSliderControls', () => {
     })
 
     it('should dispatch a SLIDE action to go back `step` pages when goBack() is called', async () => {
+      mockSliderInitialState = mockInitialInfiniteSliderState
       const { result } = renderHook(() => useSliderControls(true))
 
       await act(() => Promise.resolve())
@@ -84,10 +89,22 @@ describe('useSliderControls', () => {
         },
       })
     })
-    it.todo(
-      'should prevent SLIDE action to set `currentSlide` to a negative number if the slider is not an infinite one'
-    )
-    it.todo('should prevent over-sliding backwards')
+
+    it('should prevent SLIDE action to set `currentSlide` to a negative number if the slider is not an infinite one', async () => {
+      mockSliderInitialState = mockInitialNonInfiniteSliderState
+      const { result } = renderHook(() => useSliderControls(false))
+
+      await act(() => Promise.resolve())
+      result.current.goBack()
+
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: 'SLIDE',
+        payload: {
+          currentSlide: 0,
+          transform: 0,
+        },
+      })
+    })
   })
 
   describe('goForward()', () => {

--- a/react/__tests__/hooks.test.tsx
+++ b/react/__tests__/hooks.test.tsx
@@ -1,3 +1,22 @@
+import { hooks } from '@vtex/test-tools/react'
+
+import { useSliderState } from '../components/SliderContext'
+import { useSliderControls } from '../hooks/useSliderControls'
+import { mockInitialInfiniteSliderState } from '../__fixtures__/SliderStateContext'
+
+const { renderHook, act } = hooks
+
+const mockDispatch = jest.fn()
+
+jest.mock('../components/SliderContext', () => ({
+  useSliderState: () => mockInitialInfiniteSliderState,
+  useSliderDispatch: () => mockDispatch,
+}))
+
+beforeEach(() => {
+  mockDispatch.mockClear()
+})
+
 describe('useAutoplay', () => {
   it.todo('should call goForward() after the correct interval')
   it.todo('should stop if user is hovering the slider')
@@ -36,12 +55,35 @@ describe('useScreenResize', () => {
 
 describe('useSliderControls', () => {
   describe('goBack()', () => {
-    it.todo(
-      'should dispatch a SLIDE action to go back exactly one page when goBack() is called with no arguments'
-    )
-    it.todo(
-      'should dispatch a SLIDE action to go back `step` pages when goBack() is called'
-    )
+    it('should dispatch a SLIDE action to go back the navigationStep when goBack() is called with no arguments', async () => {
+      const { result } = renderHook(() => useSliderControls(true))
+
+      await act(() => Promise.resolve())
+      result.current.goBack()
+
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: 'SLIDE',
+        payload: {
+          currentSlide: -2,
+          transform: mockInitialInfiniteSliderState.transformMap[-2],
+        },
+      })
+    })
+
+    it('should dispatch a SLIDE action to go back `step` pages when goBack() is called', async () => {
+      const { result } = renderHook(() => useSliderControls(true))
+
+      await act(() => Promise.resolve())
+      result.current.goBack(3)
+
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: 'SLIDE',
+        payload: {
+          currentSlide: -3,
+          transform: mockInitialInfiniteSliderState.transformMap[-3],
+        },
+      })
+    })
     it.todo(
       'should prevent SLIDE action to set `currentSlide` to a negative number if the slider is not an infinite one'
     )

--- a/react/__tests__/hooks.test.tsx
+++ b/react/__tests__/hooks.test.tsx
@@ -108,17 +108,52 @@ describe('useSliderControls', () => {
   })
 
   describe('goForward()', () => {
-    it.todo(
-      'should dispatch a SLIDE action to go forward exactly one page when goForward() is called with no arguments'
-    )
-    it.todo(
-      'should dispatch a SLIDE action to go forward `step` pages when goForward() is called'
-    )
-    it.todo(
-      `should prevent SLIDE action to set \`currentSlide\` to a number greater than the total slides count if the
-       slider is not an infinite one`
-    )
-    it.todo('should prevent over-sliding forwards')
+    it('should dispatch a SLIDE action to go forward exactly one page when goForward() is called with no arguments', async () => {
+      mockSliderInitialState = mockInitialInfiniteSliderState
+      const { result } = renderHook(() => useSliderControls(true))
+
+      await act(() => Promise.resolve())
+      result.current.goForward()
+
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: 'SLIDE',
+        payload: {
+          currentSlide: 2,
+          transform: mockInitialInfiniteSliderState.transformMap[2],
+        },
+      })
+    })
+    it('should dispatch a SLIDE action to go forward `step` pages when goForward() is called', async () => {
+      mockSliderInitialState = mockInitialInfiniteSliderState
+      const { result } = renderHook(() => useSliderControls(true))
+
+      await act(() => Promise.resolve())
+      result.current.goForward(4)
+
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: 'SLIDE',
+        payload: {
+          currentSlide: 4,
+          transform: mockInitialInfiniteSliderState.transformMap[4],
+        },
+      })
+    })
+    it(`should dispatch SLIDE action to set \`currentSlide\` to the start of the last page if slider is not an infinite one`, async () => {
+      mockSliderInitialState = mockInitialNonInfiniteSliderState
+      mockSliderInitialState.currentSlide = 7
+      const { result } = renderHook(() => useSliderControls(false))
+
+      await act(() => Promise.resolve())
+      result.current.goForward(4)
+
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: 'SLIDE',
+        payload: {
+          currentSlide: 5,
+          transform: mockInitialInfiniteSliderState.transformMap[5],
+        },
+      })
+    })
   })
 })
 

--- a/react/components/SliderTrack.tsx
+++ b/react/components/SliderTrack.tsx
@@ -84,6 +84,7 @@ const SliderTrack: FC<Props> = ({
 }) => {
   const {
     slideWidth,
+    navigationStep,
     slidesPerPage,
     currentSlide,
     isOnTouchMove,
@@ -163,8 +164,8 @@ const SliderTrack: FC<Props> = ({
           dispatch({
             type: 'ADJUST_CURRENT_SLIDE',
             payload: {
-              currentSlide: totalItems - slidesPerPage,
-              transform: transformMap[totalItems - slidesPerPage],
+              currentSlide: totalItems - navigationStep,
+              transform: transformMap[totalItems - navigationStep],
             },
           })
           groupDispatch?.({

--- a/react/components/SliderTrack.tsx
+++ b/react/components/SliderTrack.tsx
@@ -84,7 +84,6 @@ const SliderTrack: FC<Props> = ({
 }) => {
   const {
     slideWidth,
-    navigationStep,
     slidesPerPage,
     currentSlide,
     isOnTouchMove,
@@ -150,13 +149,16 @@ const SliderTrack: FC<Props> = ({
           dispatch({
             type: 'ADJUST_CURRENT_SLIDE',
             payload: {
-              currentSlide: 0,
-              transform: transformMap[0],
+              currentSlide: currentSlide - totalItems,
+              transform: transformMap[currentSlide - totalItems],
             },
           })
           groupDispatch?.({
             type: 'SLIDE',
-            payload: { currentSlide: 0, transform: transformMap[0] },
+            payload: {
+              currentSlide: currentSlide - totalItems,
+              transform: transformMap[currentSlide - totalItems],
+            },
           })
         }
 
@@ -164,15 +166,15 @@ const SliderTrack: FC<Props> = ({
           dispatch({
             type: 'ADJUST_CURRENT_SLIDE',
             payload: {
-              currentSlide: totalItems - navigationStep,
-              transform: transformMap[totalItems - navigationStep],
+              currentSlide: currentSlide + totalItems,
+              transform: transformMap[currentSlide + totalItems],
             },
           })
           groupDispatch?.({
             type: 'SLIDE',
             payload: {
-              currentSlide: totalItems - slidesPerPage,
-              transform: transformMap[totalItems - slidesPerPage],
+              currentSlide: currentSlide + totalItems,
+              transform: transformMap[currentSlide + totalItems],
             },
           })
         }

--- a/react/components/SliderTrack.tsx
+++ b/react/components/SliderTrack.tsx
@@ -149,15 +149,15 @@ const SliderTrack: FC<Props> = ({
           dispatch({
             type: 'ADJUST_CURRENT_SLIDE',
             payload: {
-              currentSlide: currentSlide - totalItems,
-              transform: transformMap[currentSlide - totalItems],
+              currentSlide: 0,
+              transform: transformMap[0],
             },
           })
           groupDispatch?.({
             type: 'SLIDE',
             payload: {
-              currentSlide: currentSlide - totalItems,
-              transform: transformMap[currentSlide - totalItems],
+              currentSlide: 0,
+              transform: transformMap[0],
             },
           })
         }

--- a/react/hooks/useSliderControls.ts
+++ b/react/hooks/useSliderControls.ts
@@ -24,13 +24,13 @@ export const useSliderControls = (infinite: boolean) => {
       /** Have more slides hidden on left */
       nextSlide = nextMaximumSlides
       nextTransformValue = transformMap[nextSlide]
-    } else if (nextMaximumSlides < 0 && currentSlide !== 0) {
-      /** Prevent over-slide */
-      nextSlide = 0
-      nextTransformValue = 0
     } else if (infinite) {
       nextSlide = nextMaximumSlides
       nextTransformValue = transformMap[nextSlide]
+    } else if (nextMaximumSlides < 0) {
+      /** Prevent over-slide */
+      nextSlide = 0
+      nextTransformValue = 0
     }
 
     if (groupDispatch) {

--- a/react/hooks/useSliderControls.ts
+++ b/react/hooks/useSliderControls.ts
@@ -24,13 +24,14 @@ export const useSliderControls = (infinite: boolean) => {
       /** Have more slides hidden on left */
       nextSlide = nextMaximumSlides
       nextTransformValue = transformMap[nextSlide]
-    } else if (infinite) {
-      nextSlide = nextMaximumSlides
-      nextTransformValue = transformMap[nextSlide]
-    } else if (nextMaximumSlides < 0) {
+    } else if (currentSlide !== 0) {
       /** Prevent over-slide */
       nextSlide = 0
       nextTransformValue = 0
+    } else if (infinite) {
+      /** Have more slides hidden on left */
+      nextSlide = nextMaximumSlides
+      nextTransformValue = transformMap[nextSlide]
     }
 
     if (groupDispatch) {
@@ -64,15 +65,12 @@ export const useSliderControls = (infinite: boolean) => {
       /** There are some slides hidden on the right */
       nextSlide = currentSlide + activeNavigationStep
       nextTransformValue = transformMap[nextSlide]
-    } else if (infinite) {
-      nextSlide = currentSlide + activeNavigationStep
-      nextTransformValue = transformMap[nextSlide]
-    } else if (
-      nextMaximumSlides > totalItems &&
-      currentSlide !== totalItems - slidesPerPage
-    ) {
+    } else if (currentSlide < totalItems - slidesPerPage) {
       /** Prevent over-slide */
       nextSlide = totalItems - slidesPerPage
+      nextTransformValue = transformMap[nextSlide]
+    } else if (infinite) {
+      nextSlide = currentSlide + activeNavigationStep
       nextTransformValue = transformMap[nextSlide]
     }
 

--- a/react/hooks/useSliderControls.ts
+++ b/react/hooks/useSliderControls.ts
@@ -64,15 +64,15 @@ export const useSliderControls = (infinite: boolean) => {
       /** There are some slides hidden on the right */
       nextSlide = currentSlide + activeNavigationStep
       nextTransformValue = transformMap[nextSlide]
+    } else if (infinite) {
+      nextSlide = currentSlide + activeNavigationStep
+      nextTransformValue = transformMap[nextSlide]
     } else if (
       nextMaximumSlides > totalItems &&
       currentSlide !== totalItems - slidesPerPage
     ) {
       /** Prevent over-slide */
       nextSlide = totalItems - slidesPerPage
-      nextTransformValue = transformMap[nextSlide]
-    } else if (infinite) {
-      nextSlide = currentSlide + activeNavigationStep
       nextTransformValue = transformMap[nextSlide]
     }
 


### PR DESCRIPTION
## What problem is this solving?

This PR solves the issue pointed out at [SF-26](https://vtex-dev.atlassian.net/browse/SF-26): 
> An unexpected behavior occurs when using vtex.slider-layout, if these two props are set together:
> infinite: true and navigationStep: 1

This problem is reproduced in the gif below:
![ezgif com-gif-maker(3)](https://user-images.githubusercontent.com/8497187/179069371-fe812dbb-d9ed-4ceb-b3be-73f8e1a3c483.gif)

**Two problems can be seen:**
1) When going forward, the inifinit does not behave well and keeps going back and forth indefinitely.
2) When going back, the slide glitches and changes.

**Both were fixed as can be seen below:**
![ezgif com-gif-maker(4)](https://user-images.githubusercontent.com/8497187/179071452-fd7f4d1a-5fbf-477d-83cc-b9324cf48ff5.gif)



## How to test it?
https://danzan--hsmuniversity.myvtex.com/ is up and running with the correct behavior


## Describe alternatives you've considered, if any.

I've tried to remove the need of an additional logic to move the slider to the first/last position before going infinite, but this didn't work due to complications with the tracker.


## How does this PR make you feel?
![screen-gif](https://media.giphy.com/media/LFiOdYoOlEKac/giphy-downsized.gif)
