### PR TITLE
Add Thai and fix English and Portuguese

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Thai translation.
+
+### Fixed
+- English and Portuguese translations.
+
 ## [0.22.3] - 2022-09-05
 
 ### Added

--- a/messages/en.json
+++ b/messages/en.json
@@ -1,9 +1,9 @@
 {
-  "admin/editor.slider-layout.title": "Slider-Layout",
+  "admin/editor.slider-layout.title": "Slider Layout",
   "admin/editor.slider-layout.infinite": "Infinite",
   "admin/editor.slider-layout.showNavigation": "Show navigation arrows",
   "admin/editor.slider-layout.showPaginationDots": "Show pagination dots",
   "admin/editor.slider-layout.usePagination": "Use pagination",
   "admin/editor.slider-layout.sliderFullWidth": "Full width",
-  "admin/editor.slider-layout.sliderFullWidthDescription": "Controls whether or not the slides should fill the full available width, making the arrows appear on top of them."
+  "admin/editor.slider-layout.sliderFullWidthDescription": "Controls whether the slides should fill the full available width, making the arrows appear on top of them."
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -1,5 +1,5 @@
 {
-  "admin/editor.slider-layout.title": "Slider-Layout",
+  "admin/editor.slider-layout.title": "Layout do slider",
   "admin/editor.slider-layout.infinite": "Infinito",
   "admin/editor.slider-layout.showNavigation": "Mostrar setas para navegação",
   "admin/editor.slider-layout.showPaginationDots": "Mostrar indicadores de paginação",

--- a/messages/th-TH.json
+++ b/messages/th-TH.json
@@ -1,0 +1,9 @@
+{
+  "admin/editor.slider-layout.title": "เค้าโครงตัวเลื่อน",
+  "admin/editor.slider-layout.infinite": "ไม่จำกัด",
+  "admin/editor.slider-layout.showNavigation": "แสดงลูกศรการนำทาง",
+  "admin/editor.slider-layout.showPaginationDots": "แสดงจุดประการแบ่งหน้า",
+  "admin/editor.slider-layout.usePagination": "ใช้การแบ่งหน้า",
+  "admin/editor.slider-layout.sliderFullWidth": "ความกว้างเต็มที่",
+  "admin/editor.slider-layout.sliderFullWidthDescription": "ควบคุมว่าควรแสดงสไลด์เต็มความกว้างที่ใช้ได้หรือไม่ โดยแสดงลูกศรที่ด้านบนสุดของสไลด์"
+}


### PR DESCRIPTION
Add Thai and fix English and Portuguese translations. It relates to [LOC-9144](https://vtex-dev.atlassian.net/browse/LOC-9144) and the current admin review that the localization team is doing.