### PR TITLE
Issue shelfs slider with seletor of sku with slider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [0.3.1] - 2022-10-04
 
+### Fixed
+
+- Issue Slider Selector SKUs in shelfs with slider
+
 ## [0.0.2] - 2022-10-04
 
 ## [0.23.0] - 2022-09-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.0.2] - 2022-10-04
+
 ## [0.23.0] - 2022-09-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.3.1] - 2022-10-04
+
 ## [0.0.2] - 2022-10-04
 
 ## [0.23.0] - 2022-09-14

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "slider-layout",
   "vendor": "cirilocabos",
-  "version": "0.0.2",
+  "version": "0.3.0",
   "title": "VTEX Slider-Layout",
   "description": "A React Slider component that works well in SPA and SSR",
   "mustUpdateAt": "2020-01-30",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "slider-layout",
   "vendor": "cirilocabos",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "title": "VTEX Slider-Layout",
   "description": "A React Slider component that works well in SPA and SSR",
   "mustUpdateAt": "2020-01-30",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "slider-layout",
-  "vendor": "cirilocabos",
-  "version": "0.3.1",
+  "vendor": "vtex",
+  "version": "0.23.0",
   "title": "VTEX Slider-Layout",
   "description": "A React Slider component that works well in SPA and SSR",
   "mustUpdateAt": "2020-01-30",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "slider-layout",
   "vendor": "cirilocabos",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "title": "VTEX Slider-Layout",
   "description": "A React Slider component that works well in SPA and SSR",
   "mustUpdateAt": "2020-01-30",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "slider-layout",
-  "vendor": "vtex",
-  "version": "0.23.0",
+  "vendor": "cirilocabos",
+  "version": "0.0.1",
   "title": "VTEX Slider-Layout",
   "description": "A React Slider component that works well in SPA and SSR",
   "mustUpdateAt": "2020-01-30",

--- a/react/SliderLayout.tsx
+++ b/react/SliderLayout.tsx
@@ -40,11 +40,11 @@ function SliderLayout({
 }: PropsWithChildren<SliderLayoutProps & SliderLayoutSiteEditorProps & Props>) {
   const { handles, withModifiers } = useCssHandles(CSS_HANDLES, { classes })
   const list = useListContext()?.list ?? []
-  const totalSlides = totalItems ?? React.Children.count(children) + list.length
+  const totalSlides = totalItems ?? (children as any).length > 0 ? React.Children.count(children) : list.length
   const responsiveArrowIconSize = useResponsiveValue(arrowSize)
   const responsiveItemsPerPage = useResponsiveValue(itemsPerPage)
   const responsiveCenterMode = useResponsiveValue(centerMode)
-  const slides = React.Children.toArray(children).concat(list)
+  const slides = (children as any).length > 0 ? React.Children.toArray(children) : React.Children.toArray(list)
   // Force fullWidth mode when centerMode is on
   const resolvedFullWidth = fullWidth || responsiveCenterMode !== 'disabled'
 


### PR DESCRIPTION
#### What problem is this solving?
Problem with shelves with slider and sku selectors with sliders too


<!--- What is the motivation and context for this change? -->
The shelf has a lot of skus, I need it to be in a slider format

#### How to test?
Open a shelf with a slider and in the pros of sku-selector put it as a slider

<!--- Don't forget to add a link to a Workspace where this branch is linked -->


[Workspace](Link goes here!)
https://slider--cirilocabos.myvtex.com/

#### Screenshots or usage example:

<!--- Add some images or gifs to show the changes in behavior or layout. Example: before and after images -->
before
![image](https://user-images.githubusercontent.com/11931589/193734836-c8cf2689-e2ff-4132-a96f-cc0d641d3e17.png)
later
![image](https://user-images.githubusercontent.com/11931589/193735386-d964d39e-3e46-491a-85a5-b67d17b6221f.png)


#### Describe the alternatives you considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)
satisfied customer

<!-- Go to http://giphy.com/ and choose a gif that represents how this PR makes you feel -->

![](put the .gif link here - it can be found under "advanced" on giphy)