### PR TITLE
Fixed horizontal scroll bug on nested sliders for mobile

### DIFF
--- a/react/hooks/useTouchHandlers.ts
+++ b/react/hooks/useTouchHandlers.ts
@@ -33,6 +33,7 @@ export const useTouchHandlers = ({
   }
 
   const onTouchMove = (e: React.TouchEvent) => {
+    e.stopPropagation()
     const currentX = e.touches[0].clientX
     const touchMoveDelta = currentX - touchState.touchStartX
 
@@ -48,6 +49,7 @@ export const useTouchHandlers = ({
   }
 
   const onTouchEnd = (e: React.TouchEvent) => {
+    e.stopPropagation()
     const endX = e.changedTouches[0].clientX
     const delta = endX - touchState.touchStartX
 


### PR DESCRIPTION
#### What problem is this solving?

If you have 2 nested sliders, where on Mobile you can see both of them (for example 1 in the background and 1 in a modal), then when you use the horizontal scroll on the child slider, the parent slider also moves at the same time.
I have added `stopPropagation()` to `onTouchMove` which stops the parent slider from moving when you move the child slider. And I have also added this function to `onTouchEnd` to make sure that when you release and it moves to the next set of items, the parent does not also move along with the child.

#### How to test it?

An example:
Have a `list-context.product-list` block which contains `product-summary.shelf` in blocks and `slider-layout` in children. Then in the summary shelf use a Modal which also contains a `product-summary.shelf` and a `slider-layout`, or anything that would result in a similar slider.
Now you have 2 "nested" sliders, with the child inside a modal. If you are on Mobile and position the parent div on the top of your screen (this is so that you see both at the same time, parent on top in the background and child in center in modal) and if you move the child slider, the parent will not change.

#### Screenshots or example usage:

Parent slider by default without moving:
<img width="274" alt="parentSlider" src="https://user-images.githubusercontent.com/91942975/202781028-48635c05-0dc1-4b7b-826c-61f4216896ef.png">

Before (child moves parent)
<img width="245" alt="beforeSliders" src="https://user-images.githubusercontent.com/91942975/202781057-70563471-4322-49df-ba19-400c92742c35.png">

After (child does not move parent)
<img width="253" alt="afterSliders" src="https://user-images.githubusercontent.com/91942975/202781146-3d485d2d-a266-4e2c-94e6-7adba46d50e7.png">

