### PR TITLE
Feat/set up enumNames on schema and add pt/en translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 - Added translation for the Dropdown options on props `showNavigationArrows` and `showPaginationDots`
+- Translations for Bulgarian, German, Spanish, French, Italian, Korean, Dutch, Portuguese, Romanian and Thai.
 
 ## [0.24.3] - 2023-05-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
-
-- Added translations for Bulgarian, German, Spanish, French, Italian, Korean, Dutch, Portuguese, Romanian and Thai.
-
-### Added
 - Added translation for the Dropdown options on props `showNavigationArrows` and `showPaginationDots`
 
 ## [0.24.3] - 2023-05-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-### Addedd
+### Added
 - Added translation for the Dropdown options on props `showNavigationArrows` and `showPaginationDots`
 
 ## [0.24.3] - 2023-05-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Addedd
+- Added translation for the Dropdown options on props `showNavigationArrows` and `showPaginationDots`
+
 ## [0.24.3] - 2023-05-08
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
+
+- Added translations for Bulgarian, German, Spanish, French, Italian, Korean, Dutch, Portuguese, Romanian and Thai.
+
+### Added
 - Added translation for the Dropdown options on props `showNavigationArrows` and `showPaginationDots`
 
 ## [0.24.3] - 2023-05-08

--- a/messages/bg-BG.json
+++ b/messages/bg-BG.json
@@ -5,5 +5,9 @@
   "admin/editor.slider-layout.showPaginationDots": "Показване на точки за страниране",
   "admin/editor.slider-layout.usePagination": "Използване на страниране",
   "admin/editor.slider-layout.sliderFullWidth": "Пълна ширина",
-  "admin/editor.slider-layout.sliderFullWidthDescription": "Контролира дали слайдовете да изпълват цялата налична ширина, а стрелките да се виждат върху тях."
+  "admin/editor.slider-layout.sliderFullWidthDescription": "Контролира дали слайдовете да изпълват цялата налична ширина, а стрелките да се виждат върху тях.",
+  "admin/editor.slider-layout.sliderNavigationAndPaginationPropertyMobileOnly": "Само за мобилни устройства",
+  "admin/editor.slider-layout.sliderNavigationAndPaginationPropertyDesktopOnly": "Само за настолен компютър",
+  "admin/editor.slider-layout.sliderNavigationAndPaginationPropertyAlways": "Винаги",
+  "admin/editor.slider-layout.sliderNavigationAndPaginationPropertyNever": "Никога"
 }

--- a/messages/de-DE.json
+++ b/messages/de-DE.json
@@ -5,5 +5,9 @@
   "admin/editor.slider-layout.showPaginationDots": "Seitenumbruch-Punkte anzeigen",
   "admin/editor.slider-layout.usePagination": "Seitennavigation verwenden",
   "admin/editor.slider-layout.sliderFullWidth": "Volle Breite",
-  "admin/editor.slider-layout.sliderFullWidthDescription": "Legt fest, ob die Diapositive die volle verfügbare Breite füllen sollen, so dass die Pfeile oben auf ihnen erscheinen."
+  "admin/editor.slider-layout.sliderFullWidthDescription": "Legt fest, ob die Diapositive die volle verfügbare Breite füllen sollen, so dass die Pfeile oben auf ihnen erscheinen.",
+  "admin/editor.slider-layout.sliderNavigationAndPaginationPropertyMobileOnly": "Nur mobil",
+  "admin/editor.slider-layout.sliderNavigationAndPaginationPropertyDesktopOnly": "Nur Desktop",
+  "admin/editor.slider-layout.sliderNavigationAndPaginationPropertyAlways": "Immer",
+  "admin/editor.slider-layout.sliderNavigationAndPaginationPropertyNever": "Niemals"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -5,5 +5,9 @@
   "admin/editor.slider-layout.showPaginationDots": "Show pagination dots",
   "admin/editor.slider-layout.usePagination": "Use pagination",
   "admin/editor.slider-layout.sliderFullWidth": "Full width",
-  "admin/editor.slider-layout.sliderFullWidthDescription": "Controls whether the slides should fill the full available width, making the arrows appear on top of them."
+  "admin/editor.slider-layout.sliderFullWidthDescription": "Controls whether the slides should fill the full available width, making the arrows appear on top of them.",
+  "admin/editor.slider-layout.sliderNavigationAndPaginationPropertyMobileOnly": "Mobile Only",
+  "admin/editor.slider-layout.sliderNavigationAndPaginationPropertyDesktopOnly": "Desktop Only",
+  "admin/editor.slider-layout.sliderNavigationAndPaginationPropertyAlways": "Always",
+  "admin/editor.slider-layout.sliderNavigationAndPaginationPropertyNever": "Never"
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -5,5 +5,9 @@
   "admin/editor.slider-layout.showPaginationDots": "Mostrar puntos de paginación",
   "admin/editor.slider-layout.usePagination": "Usar paginación",
   "admin/editor.slider-layout.sliderFullWidth": "Anchura completa",
-  "admin/editor.slider-layout.sliderFullWidthDescription": "Controla si las diapositivas deben ocupar la anchura completa y hacer que las flechas desaparezcan encima de ellas."
+  "admin/editor.slider-layout.sliderFullWidthDescription": "Controla si las diapositivas deben ocupar la anchura completa y hacer que las flechas desaparezcan encima de ellas.",
+  "admin/editor.slider-layout.sliderNavigationAndPaginationPropertyMobileOnly": "Solo móvil",
+  "admin/editor.slider-layout.sliderNavigationAndPaginationPropertyDesktopOnly": "Solo escritorio",
+  "admin/editor.slider-layout.sliderNavigationAndPaginationPropertyAlways": "Siempre",
+  "admin/editor.slider-layout.sliderNavigationAndPaginationPropertyNever": "Nunca"
 }

--- a/messages/fr-FR.json
+++ b/messages/fr-FR.json
@@ -5,5 +5,9 @@
   "admin/editor.slider-layout.showPaginationDots": "Afficher les points de pagination",
   "admin/editor.slider-layout.usePagination": "Utiliser la pagination",
   "admin/editor.slider-layout.sliderFullWidth": "Largeur totale",
-  "admin/editor.slider-layout.sliderFullWidthDescription": "Vérifie si les diapos doivent ou non remplir toute la largeur disponible, en faisant apparaître les flèches au-dessus d’elles."
+  "admin/editor.slider-layout.sliderFullWidthDescription": "Vérifie si les diapos doivent ou non remplir toute la largeur disponible, en faisant apparaître les flèches au-dessus d’elles.",
+  "admin/editor.slider-layout.sliderNavigationAndPaginationPropertyMobileOnly": "Mobile uniquement",
+  "admin/editor.slider-layout.sliderNavigationAndPaginationPropertyDesktopOnly": "Bureau uniquement",
+  "admin/editor.slider-layout.sliderNavigationAndPaginationPropertyAlways": "Toujours",
+  "admin/editor.slider-layout.sliderNavigationAndPaginationPropertyNever": "Jamais"
 }

--- a/messages/it-IT.json
+++ b/messages/it-IT.json
@@ -5,5 +5,9 @@
   "admin/editor.slider-layout.showPaginationDots": "Mostra punti di impaginazione",
   "admin/editor.slider-layout.usePagination": "Utilizza impaginazione",
   "admin/editor.slider-layout.sliderFullWidth": "Larghezza massima",
-  "admin/editor.slider-layout.sliderFullWidthDescription": "Controlla se le diapositive debbano occupare o meno l'intera larghezza disponibile, facendo in modo che le frecce appaiano su di esse."
+  "admin/editor.slider-layout.sliderFullWidthDescription": "Controlla se le diapositive debbano occupare o meno l'intera larghezza disponibile, facendo in modo che le frecce appaiano su di esse.",
+  "admin/editor.slider-layout.sliderNavigationAndPaginationPropertyMobileOnly": "Solo dispositivi mobili",
+  "admin/editor.slider-layout.sliderNavigationAndPaginationPropertyDesktopOnly": "Solo desktop",
+  "admin/editor.slider-layout.sliderNavigationAndPaginationPropertyAlways": "Sempre",
+  "admin/editor.slider-layout.sliderNavigationAndPaginationPropertyNever": "Mai"
 }

--- a/messages/ko-KR.json
+++ b/messages/ko-KR.json
@@ -5,5 +5,9 @@
   "admin/editor.slider-layout.showPaginationDots": "페이지 번호 점 표시",
   "admin/editor.slider-layout.usePagination": "페이지 번호 사용",
   "admin/editor.slider-layout.sliderFullWidth": "전체 넓이",
-  "admin/editor.slider-layout.sliderFullWidthDescription": "슬라이드가 사용 가능한 전체 너비를 채워, 화살표가 맨 위에 나타나는지 여부를 제어합니다."
+  "admin/editor.slider-layout.sliderFullWidthDescription": "슬라이드가 사용 가능한 전체 너비를 채워, 화살표가 맨 위에 나타나는지 여부를 제어합니다.",
+  "admin/editor.slider-layout.sliderNavigationAndPaginationPropertyMobileOnly": "모바일 전용",
+  "admin/editor.slider-layout.sliderNavigationAndPaginationPropertyDesktopOnly": "데스크톱 전용",
+  "admin/editor.slider-layout.sliderNavigationAndPaginationPropertyAlways": "항상",
+  "admin/editor.slider-layout.sliderNavigationAndPaginationPropertyNever": "안 함"
 }

--- a/messages/nl-NL.json
+++ b/messages/nl-NL.json
@@ -5,5 +5,9 @@
   "admin/editor.slider-layout.showPaginationDots": "Toon pagineringstippen",
   "admin/editor.slider-layout.usePagination": "Gebruik paginering",
   "admin/editor.slider-layout.sliderFullWidth": "Volledige breedte",
-  "admin/editor.slider-layout.sliderFullWidthDescription": "Bepaalt of de dia's de volledige beschikbare breedte moeten vullen, waardoor de pijlen erboven verschijnen."
+  "admin/editor.slider-layout.sliderFullWidthDescription": "Bepaalt of de dia's de volledige beschikbare breedte moeten vullen, waardoor de pijlen erboven verschijnen.",
+  "admin/editor.slider-layout.sliderNavigationAndPaginationPropertyMobileOnly": "Alleen mobiel",
+  "admin/editor.slider-layout.sliderNavigationAndPaginationPropertyDesktopOnly": "Alleen desktop",
+  "admin/editor.slider-layout.sliderNavigationAndPaginationPropertyAlways": "Altijd",
+  "admin/editor.slider-layout.sliderNavigationAndPaginationPropertyNever": "Nooit"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -5,5 +5,9 @@
   "admin/editor.slider-layout.showPaginationDots": "Mostrar indicadores de paginação",
   "admin/editor.slider-layout.usePagination": "Usar paginação",
   "admin/editor.slider-layout.sliderFullWidth": "Largura completa",
-  "admin/editor.slider-layout.sliderFullWidthDescription": "Controla se os slides devem ou não ocupar toda a largura disponível, fazendo as setas aparecerem sobre eles."
+  "admin/editor.slider-layout.sliderFullWidthDescription": "Controla se os slides devem ou não ocupar toda a largura disponível, fazendo as setas aparecerem sobre eles.",
+  "admin/editor.slider-layout.sliderNavigationAndPaginationPropertyMobileOnly": "Apenas Mobile",
+  "admin/editor.slider-layout.sliderNavigationAndPaginationPropertyDesktopOnly": "Apenas Desktop",
+  "admin/editor.slider-layout.sliderNavigationAndPaginationPropertyAlways": "Sempre",
+  "admin/editor.slider-layout.sliderNavigationAndPaginationPropertyNever": "Nunca"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -6,8 +6,8 @@
   "admin/editor.slider-layout.usePagination": "Usar paginação",
   "admin/editor.slider-layout.sliderFullWidth": "Largura completa",
   "admin/editor.slider-layout.sliderFullWidthDescription": "Controla se os slides devem ou não ocupar toda a largura disponível, fazendo as setas aparecerem sobre eles.",
-  "admin/editor.slider-layout.sliderNavigationAndPaginationPropertyMobileOnly": "Apenas Mobile",
-  "admin/editor.slider-layout.sliderNavigationAndPaginationPropertyDesktopOnly": "Apenas Desktop",
+  "admin/editor.slider-layout.sliderNavigationAndPaginationPropertyMobileOnly": "Somente dispositivos móveis",
+  "admin/editor.slider-layout.sliderNavigationAndPaginationPropertyDesktopOnly": "Somente desktop",
   "admin/editor.slider-layout.sliderNavigationAndPaginationPropertyAlways": "Sempre",
   "admin/editor.slider-layout.sliderNavigationAndPaginationPropertyNever": "Nunca"
 }

--- a/messages/ro-RO.json
+++ b/messages/ro-RO.json
@@ -5,5 +5,9 @@
   "admin/editor.slider-layout.showPaginationDots": "Arată punctele de paginație",
   "admin/editor.slider-layout.usePagination": "Folosește paginația",
   "admin/editor.slider-layout.sliderFullWidth": "Lățime completă",
-  "admin/editor.slider-layout.sliderFullWidthDescription": "Controlează dacă slide-urile trebuie sau nu să ocupe întreaga lățime disponibilă, făcând ca săgețile să apară deasupra lor."
+  "admin/editor.slider-layout.sliderFullWidthDescription": "Controlează dacă slide-urile trebuie sau nu să ocupe întreaga lățime disponibilă, făcând ca săgețile să apară deasupra lor.",
+  "admin/editor.slider-layout.sliderNavigationAndPaginationPropertyMobileOnly": "Doar pentru mobil",
+  "admin/editor.slider-layout.sliderNavigationAndPaginationPropertyDesktopOnly": "Doar pentru desktop",
+  "admin/editor.slider-layout.sliderNavigationAndPaginationPropertyAlways": "Mereu",
+  "admin/editor.slider-layout.sliderNavigationAndPaginationPropertyNever": "Niciodată"
 }

--- a/messages/th-TH.json
+++ b/messages/th-TH.json
@@ -5,5 +5,9 @@
   "admin/editor.slider-layout.showPaginationDots": "แสดงจุดประการแบ่งหน้า",
   "admin/editor.slider-layout.usePagination": "ใช้การแบ่งหน้า",
   "admin/editor.slider-layout.sliderFullWidth": "ความกว้างเต็มที่",
-  "admin/editor.slider-layout.sliderFullWidthDescription": "ควบคุมว่าควรแสดงสไลด์เต็มความกว้างที่ใช้ได้หรือไม่ โดยแสดงลูกศรที่ด้านบนสุดของสไลด์"
+  "admin/editor.slider-layout.sliderFullWidthDescription": "ควบคุมว่าควรแสดงสไลด์เต็มความกว้างที่ใช้ได้หรือไม่ โดยแสดงลูกศรที่ด้านบนสุดของสไลด์",
+  "admin/editor.slider-layout.sliderNavigationAndPaginationPropertyMobileOnly": "เฉพาะอุปกรณ์เคลื่อนที่",
+  "admin/editor.slider-layout.sliderNavigationAndPaginationPropertyDesktopOnly": "เฉพาะเดสก์ท็อป",
+  "admin/editor.slider-layout.sliderNavigationAndPaginationPropertyAlways": "ทุกครั้ง",
+  "admin/editor.slider-layout.sliderNavigationAndPaginationPropertyNever": "ไม่ต้อง"
 }

--- a/react/SliderLayout.tsx
+++ b/react/SliderLayout.tsx
@@ -106,6 +106,22 @@ const messages = defineMessages({
     id: 'admin/editor.slider-layout.sliderFullWidthDescription',
     defaultMessage: '',
   },
+  sliderNavigationAndPaginationPropertyMobileOnly: {
+    id: 'admin/editor.slider-layout.sliderNavigationAndPaginationPropertyMobileOnly',
+    defaultMessage: '',
+  },
+  sliderNavigationAndPaginationPropertyDesktopOnly: {
+    id: 'admin/editor.slider-layout.sliderNavigationAndPaginationPropertyDesktopOnly',
+    defaultMessage: '',
+  },
+  sliderNavigationAndPaginationPropertyAlways: {
+    id: 'admin/editor.slider-layout.sliderNavigationAndPaginationPropertyAlways',
+    defaultMessage: '',
+  },
+  sliderNavigationAndPaginationPropertyNever: {
+    id: 'admin/editor.slider-layout.sliderNavigationAndPaginationPropertyNever',
+    defaultMessage: '',
+  },
 })
 
 SliderLayout.schema = {

--- a/react/SliderLayout.tsx
+++ b/react/SliderLayout.tsx
@@ -107,15 +107,18 @@ const messages = defineMessages({
     defaultMessage: '',
   },
   sliderNavigationAndPaginationPropertyMobileOnly: {
-    id: 'admin/editor.slider-layout.sliderNavigationAndPaginationPropertyMobileOnly',
+    id:
+      'admin/editor.slider-layout.sliderNavigationAndPaginationPropertyMobileOnly',
     defaultMessage: '',
   },
   sliderNavigationAndPaginationPropertyDesktopOnly: {
-    id: 'admin/editor.slider-layout.sliderNavigationAndPaginationPropertyDesktopOnly',
+    id:
+      'admin/editor.slider-layout.sliderNavigationAndPaginationPropertyDesktopOnly',
     defaultMessage: '',
   },
   sliderNavigationAndPaginationPropertyAlways: {
-    id: 'admin/editor.slider-layout.sliderNavigationAndPaginationPropertyAlways',
+    id:
+      'admin/editor.slider-layout.sliderNavigationAndPaginationPropertyAlways',
     defaultMessage: '',
   },
   sliderNavigationAndPaginationPropertyNever: {

--- a/store/contentSchemas.json
+++ b/store/contentSchemas.json
@@ -11,12 +11,24 @@
         "showNavigationArrows": {
           "default": "always",
           "enum": ["mobileOnly", "desktopOnly", "always", "never"],
+          "enumNames": [
+            "admin/editor.slider-layout.sliderNavigationAndPaginationPropertyMobileOnly",
+            "admin/editor.slider-layout.sliderNavigationAndPaginationPropertyDesktopOnly",
+            "admin/editor.slider-layout.sliderNavigationAndPaginationPropertyAlways",
+            "admin/editor.slider-layout.sliderNavigationAndPaginationPropertyNever"
+          ],
           "title": "admin/editor.slider-layout.showNavigation",
           "type": "string"
         },
         "showPaginationDots": {
           "default": "always",
           "enum": ["mobileOnly", "desktopOnly", "always", "never"],
+          "enumNames": [
+            "admin/editor.slider-layout.sliderNavigationAndPaginationPropertyMobileOnly",
+            "admin/editor.slider-layout.sliderNavigationAndPaginationPropertyDesktopOnly",
+            "admin/editor.slider-layout.sliderNavigationAndPaginationPropertyAlways",
+            "admin/editor.slider-layout.sliderNavigationAndPaginationPropertyNever"
+          ],
           "title": "admin/editor.slider-layout.showPaginationDots",
           "type": "string"
         },


### PR DESCRIPTION
#### What problem is this solving?

Add translations for the dropdown options for the props `showNavigationArrows` and `showPaginationDots`

#### How to test it?

* Switch to this branch and link to workspace
* Go to https://{workspace}--{account}.myvtex.com/admin/cms/site-editor -> Image List -> Slider Layout
* Check if the options the `Show navigation arrows` and `Show pagination dots` dropdowns are correctly translated

[Workspace](https://natandevuamerge--storecomponents.myvtex.com/admin/cms/site-editor)

#### Screenshots or example usage:

![Captura de Tela 2023-05-23 às 17 09 02](https://github.com/vtex-apps/slider-layout/assets/36740164/b72f358f-19d2-4035-a823-1355684fa45f)


#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/XK7VBhOwU9FlrcZQZg/giphy.gif)
