### PR TITLE
feat: centerModeSlidesGap can be number zero

### DIFF
--- a/react/components/SliderContext.tsx
+++ b/react/components/SliderContext.tsx
@@ -1,9 +1,9 @@
 import React, {
-  createContext,
-  useReducer,
-  useContext,
   FC,
+  createContext,
+  useContext,
   useMemo,
+  useReducer,
   useState,
 } from 'react'
 import { ResponsiveValuesTypes } from 'vtex.responsive-values'
@@ -250,7 +250,7 @@ const SliderContextProvider: FC<SliderContextProps> = ({
       resultingSlideWidth =
         (resolvedSlidesPerPage / (resolvedSlidesPerPage + 1)) * baseSlideWidth
 
-      if (centerMode === 'to-the-left' && centerModeSlidesGap) {
+      if (centerMode === 'to-the-left' && centerModeSlidesGap !== undefined) {
         resultingSlideWidth =
           (baseSlideWidth * resolvedSlidesPerPage) /
           (resolvedSlidesPerPage + 1 / 2)
@@ -288,7 +288,7 @@ const SliderContextProvider: FC<SliderContextProps> = ({
           transformValue += transformCenterCorrection
         }
 
-        if (centerModeSlidesGap) {
+        if (centerModeSlidesGap !== undefined) {
           transformValue =
             centerMode === 'center'
               ? -(slideWidth * (idx - 1 / 2))

--- a/react/components/SliderTrack.tsx
+++ b/react/components/SliderTrack.tsx
@@ -1,13 +1,13 @@
 import React, { cloneElement, FC, ReactElement, ReactNode } from 'react'
 
-import {
-  useSliderState,
-  useSliderDispatch,
-  SliderLayoutProps,
-} from './SliderContext'
-import { useSliderGroupDispatch } from '../SliderLayoutGroup'
 import { useSliderVisibility } from '../hooks/useSliderVisibility'
 import { useContextCssHandles } from '../modules/cssHandles'
+import { useSliderGroupDispatch } from '../SliderLayoutGroup'
+import {
+  SliderLayoutProps,
+  useSliderDispatch,
+  useSliderState,
+} from './SliderContext'
 
 export const CSS_HANDLES = [
   'sliderTrack',
@@ -190,19 +190,19 @@ const SliderTrack: FC<Props> = ({
         const slideContainerStyles = {
           width: `${slideWidth}%`,
           marginLeft:
-            centerMode !== 'disabled' && !centerModeSlidesGap
+            centerMode !== 'disabled' && centerModeSlidesGap === undefined
               ? `${slideWidth / (8 * slidesPerPage)}%`
               : undefined,
           marginRight:
-            centerMode !== 'disabled' && !centerModeSlidesGap
+            centerMode !== 'disabled' && centerModeSlidesGap === undefined
               ? `${slideWidth / (8 * slidesPerPage)}%`
               : undefined,
           paddingLeft:
-            centerMode !== 'disabled' && centerModeSlidesGap
+            centerMode !== 'disabled' && centerModeSlidesGap !== undefined
               ? centerModeSlidesGap / 2
               : undefined,
           paddingRight:
-            centerMode !== 'disabled' && centerModeSlidesGap
+            centerMode !== 'disabled' && centerModeSlidesGap !== undefined
               ? centerModeSlidesGap / 2
               : undefined,
         }


### PR DESCRIPTION
#### What problem is this solving?

`"centerModeSlidesGap": 0` doesn't work as slider-layout prop block when we don't want spacing between slides.

`centerModeSlidesGap` can be number zero and the checks on code doesn't support that.

#### How to test it?

Using `"centerModeSlidesGap": 0` on slider-layout block.