### PR TITLE
correção sku-selector dentro do slider-layout

### DIFF
--- a/react/SliderLayout.tsx
+++ b/react/SliderLayout.tsx
@@ -40,11 +40,11 @@ function SliderLayout({
 }: PropsWithChildren<SliderLayoutProps & SliderLayoutSiteEditorProps & Props>) {
   const { handles, withModifiers } = useCssHandles(CSS_HANDLES, { classes })
   const list = useListContext()?.list ?? []
-  const totalSlides = totalItems ?? React.Children.count(children) + list.length
+  const totalSlides = totalItems ?? (children as any).length > 0 ? React.Children.count(children) : list.length
   const responsiveArrowIconSize = useResponsiveValue(arrowSize)
   const responsiveItemsPerPage = useResponsiveValue(itemsPerPage)
   const responsiveCenterMode = useResponsiveValue(centerMode)
-  const slides = React.Children.toArray(children).concat(list)
+  const slides = (children as any).length > 0 ? React.Children.toArray(children) : React.Children.toArray(list)
   // Force fullWidth mode when centerMode is on
   const resolvedFullWidth = fullWidth || responsiveCenterMode !== 'disabled'
 


### PR DESCRIPTION
#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

Estou implementando o componente Product Summary SKU Selector dentro de um slider-layout, porém, quando clico no arrow do componente, a prateleira faz um comportamento inesperado.

Esse foi o desenvolvedor que realizou a correção, e eu preciso dela para finalizar meu componente.

https://github.com/vtex-apps/store-discussion/issues/618

#### How to test it?

Insira dentro de um slider layout uma prateleira de itens e dentro dela insira o componente Product Summary SKU Selector com esta correção, o comportamento inesperado será resolvido.

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://devclaudio8--rotadomar.myvtex.com/)
